### PR TITLE
Allow semicolon at end of procedure

### DIFF
--- a/src/extension/regexpCreator.ts
+++ b/src/extension/regexpCreator.ts
@@ -1,6 +1,6 @@
 export class RegExpCreator{
     public static matchWholeProcedureCall = /(?:(?<returnVar>"[ \w.-]+"|\w+)\s*:=\s*)?(?:(?<calledObj>"[ \w.-]+"|\w+)\.)?(?<calledProc>"[ \w.-]+"|\w+)\((?<params>.*)\)$/;
-    public static matchProcedureOrTriggerDeclarationLine = /(?:procedure|trigger)\s(?<procedurename>"[ \w.-]+"|\w+)\((?<parameterDeclarations>.*)\)(?::\s*(?<returnType>[\w\[\]]+))?$/;
+    public static matchProcedureOrTriggerDeclarationLine = /(?:procedure|trigger)\s(?<procedurename>"[ \w.-]+"|\w+)\((?<parameterDeclarations>.*)\)(?::\s*(?<returnType>[\w\[\]]+))?(?:\s*;)?$/;
     public static matchObjectDeclarationLine = /^(?<objectType>\w+)\s+(?<objectId>\d+)\s+(?<objectName>"[ \w.-]+"|\w+)/i;
     public static matchVariableDeclaration = /^(?<isVar>var )?(?<variableName>"[ \w.-]+"|\w+)\s*:\s*(?:array\s*\[(?<dimensions>[ \d,]+)\] of )?(?<variableType>\w+)\s*(?:\[(?<length>\d+)\]|(?<variableSubtype>"[ \w.-]+"|\w+)(?<isTemporary> temporary)?)?/i;
 }


### PR DESCRIPTION
If a procedure had a semicolon at the end of the procedure declaration, then a codeaction could not be created. (e. g. `trigger OnOpenPage();` )
