### PR TITLE
Use tree nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to the "al-codeactions" extension will be documented in this file.
 
+## 0.2.2
+
+- Create Procedure Code Action
+  - supports creation of procedure in Test-Methods
+  - supports various more statements where procedures could be created and the return type is identified correctly, e.g.:
+    - As parameter of another procedure call: The procedure takes the type of the appropriate parameter as return value.
+    - If Statement: created procedure returns boolean
+    - Assignment statement: created procedure returns the type of the variable which will be assigned
+    - Mathematical statements like add, subtract, multiply: created procedure returns Decimal or Integer
+    - Logical Statements like "true && notexistingprocedure()" returns boolean
+    - ...
+  - supports creation of multiline procedures
+  - temporary variables will be declared as var-Parameters
+- Extract to procedure Code Action
+  - Remove "Preferred Fix"-Property as it isn't working and does not make much sense.
+  - hand over the return value of a procedure if it is used inside the selection
+- Technical rebuild of extension
+
+## 0.2.1
+
+- Improvement to "Create Procedure": Rec and xRec are now recognized in Tables, Pages, Request Pages and Codeunits.
+- small bugfix if a dot was included in the variable name
+
 ## 0.2.0
 
 - First (beta) version of the "Extract procedure"-function.

--- a/src/extension/AL Code Outline Ext/alFullSyntaxTreeNodeExt.ts
+++ b/src/extension/AL Code Outline Ext/alFullSyntaxTreeNodeExt.ts
@@ -1,6 +1,8 @@
 import * as vscode from 'vscode';
 import { ALFullSyntaxTreeNode } from "../AL Code Outline/alFullSyntaxTreeNode";
 import { downloadAndUnzipVSCode } from "vscode-test";
+import { FullSyntaxTreeNodeKind } from './fullSyntaxTreeNodeKind';
+import { TextRangeExt } from './textRangeExt';
 
 export class ALFullSyntaxTreeNodeExt {
     public static collectChildNodes(treeNode: ALFullSyntaxTreeNode, kindOfSyntaxTreeNode: string, searchAllLevels: boolean, outList: ALFullSyntaxTreeNode[]) {
@@ -13,6 +15,15 @@ export class ALFullSyntaxTreeNodeExt {
                     this.collectChildNodes(treeNode.childNodes[i], kindOfSyntaxTreeNode, searchAllLevels, outList);
                 }
             }
+        }
+    }
+    public static getFirstChildNodeOfKind(treeNode: ALFullSyntaxTreeNode, kindOfSyntaxTreeNode: string, searchAllLevels: boolean): ALFullSyntaxTreeNode | undefined {
+        let outList: ALFullSyntaxTreeNode[] = [];
+        this.collectChildNodes(treeNode, kindOfSyntaxTreeNode, searchAllLevels, outList);
+        if (outList.length === 0) {
+            return undefined;
+        } else {
+            return outList[0];
         }
     }
 
@@ -72,5 +83,24 @@ export class ALFullSyntaxTreeNodeExt {
             node = (node.childNodes as ALFullSyntaxTreeNode[])[index];
         });
         return node;
+    }
+    public static getValueOfPropertyName(mainNode: ALFullSyntaxTreeNode, propertyName: string): ALFullSyntaxTreeNode | undefined {
+        let propertyLists: ALFullSyntaxTreeNode[] = [];
+        ALFullSyntaxTreeNodeExt.collectChildNodes(mainNode, FullSyntaxTreeNodeKind.getPropertyList(), false, propertyLists);
+        if (propertyLists.length === 1) {
+            let propertyList: ALFullSyntaxTreeNode = propertyLists[0];
+            let properties: ALFullSyntaxTreeNode[] = [];
+            ALFullSyntaxTreeNodeExt.collectChildNodes(propertyList, FullSyntaxTreeNodeKind.getProperty(), false, properties);
+            if (properties.length > 0) {
+                let propertiesOfSearchedProperty: ALFullSyntaxTreeNode[] = properties.filter(property => property.name && property.name.trim().toLowerCase() === propertyName.trim().toLowerCase());
+                if (propertiesOfSearchedProperty.length > 0) {
+                    let propertyOfSearchedProperty: ALFullSyntaxTreeNode = propertiesOfSearchedProperty[0];
+                    if (propertyOfSearchedProperty.childNodes && propertyOfSearchedProperty.childNodes.length === 2) {
+                        return propertyOfSearchedProperty.childNodes[1];
+                    }
+                }
+            }
+        }
+        return undefined;
     }
 }

--- a/src/extension/AL Code Outline Ext/fullSyntaxTreeNodeKind.ts
+++ b/src/extension/AL Code Outline Ext/fullSyntaxTreeNodeKind.ts
@@ -11,6 +11,12 @@ export class FullSyntaxTreeNodeKind {
     public static getField(): string {
         return 'Field'; //Tablefield
     }
+    public static getTableObject(): string {
+        return 'TableObject';
+    }
+    public static getPageObject(): string {
+        return 'PageObject';
+    }
     public static getCodeunitObject(): string {
         return 'CodeunitObject';
     }
@@ -19,6 +25,12 @@ export class FullSyntaxTreeNodeKind {
     }
     public static getReportDataItem(): string {
         return 'ReportDataItem';
+    }
+    public static getParameterList(): string {
+        return 'ParameterList';
+    }
+    public static getParameter(): string {
+        return 'Parameter';
     }
     public static getPropertyList(): string {
         return 'PropertyList';
@@ -49,6 +61,18 @@ export class FullSyntaxTreeNodeKind {
     }
     public static getMethodDeclaration(): string {
         return 'MethodDeclaration';
+    }
+    public static getGlobalVarSection(): string {
+        return 'GlobalVarSection';
+    }
+    public static getVarSection(): string {
+        return 'VarSection';
+    }
+    public static getVariableDeclaration(): string {
+        return 'VariableDeclaration';
+    }
+    public static getMemberAccessExpression(): string {
+        return 'MemberAccessExpression';
     }
     public static getIdentifierName(): string {
         return 'IdentifierName';

--- a/src/extension/AL Code Outline Ext/fullSyntaxTreeNodeKind.ts
+++ b/src/extension/AL Code Outline Ext/fullSyntaxTreeNodeKind.ts
@@ -14,23 +14,44 @@ export class FullSyntaxTreeNodeKind {
     public static getTableObject(): string {
         return 'TableObject';
     }
+    public static getTableExtensionObject(): string {
+        return 'TableExtensionObject';
+    }
     public static getPageObject(): string {
         return 'PageObject';
     }
+    public static getPageExtensionObject(): string {
+        return 'PageExtensionObject';
+    }
+    public static getPageCustomizationObject(): string {
+        return 'PageCustomizationObject';
+    }
     public static getCodeunitObject(): string {
         return 'CodeunitObject';
+    }
+    public static getReportObject(): string {
+        return 'ReportObject';
+    }
+    public static getXmlPortObject(): string {
+        return 'XmlPortObject';
+    }
+    public static getEnumType(): string{
+        return 'EnumType';
+    }
+    public static getEnumExtensionType(): string{
+        return 'EnumExtensionType';
+    }
+    public static getProfileObject(): string{
+        return 'ProfileObject';
+    }
+    public static getInterface(): string {
+        return 'Interface';
     }
     public static getRequestPage(): string {
         return 'RequestPage';
     }
     public static getReportDataItem(): string {
         return 'ReportDataItem';
-    }
-    public static getParameterList(): string {
-        return 'ParameterList';
-    }
-    public static getParameter(): string {
-        return 'Parameter';
     }
     public static getPropertyList(): string {
         return 'PropertyList';
@@ -70,6 +91,12 @@ export class FullSyntaxTreeNodeKind {
     }
     public static getVariableDeclaration(): string {
         return 'VariableDeclaration';
+    }
+    public static getVariableListDeclaration(): string {
+        return 'VariableListDeclaration';
+    }
+    public static getVariableDeclarationName(): string {
+        return 'VariableDeclarationName';
     }
     public static getMemberAccessExpression(): string {
         return 'MemberAccessExpression';
@@ -140,20 +167,8 @@ export class FullSyntaxTreeNodeKind {
     public static getOptionAccessExpression(): string {
         return 'OptionAccessExpression';
     }
-    public static getMemberAccessExpression(): string {
-        return 'MemberAccessExpression';
-    }
     public static getArrayIndexExpression(): string {
         return 'ArrayIndexExpression';
-    }
-    public static getGlobalVarSection(): string {
-        return 'GlobalVarSection';
-    }
-    public static getVarSection(): string {
-        return 'VarSection';
-    }
-    public static getVariableDeclaration(): string {
-        return 'VariableDeclaration';
     }
     public static getParameterList(): string {
         return 'ParameterList';
@@ -169,5 +184,29 @@ export class FullSyntaxTreeNodeKind {
     }
     public static getReturnValue(): string {
         return "ReturnValue";
+    }
+    public static getLiteralExpression(): string {
+        return 'LiteralExpression';
+    }
+    public static getBooleanLiteralValue(): string {
+        return 'BooleanLiteralValue';
+    }
+    public static getStringLiteralValue(): string {
+        return 'StringLiteralValue';
+    }
+    public static getInt32SignedLiteralValue(): string {
+        return 'Int32SignedLiteralValue';
+    }
+    public static getDecimalSignedLiteralValue(): string {
+        return 'DecimalSignedLiteralValue';
+    }
+    public static getUnaryMinusExpression(): string {
+        return 'UnaryMinusExpression';
+    }
+    public static getUnaryPlusExpression(): string {
+        return 'UnaryPlusExpression';
+    }
+    public static getObjectId(): string {
+        return 'ObjectId';
     }
 }

--- a/src/extension/AL Code Outline Ext/syntaxTreeExt.ts
+++ b/src/extension/AL Code Outline Ext/syntaxTreeExt.ts
@@ -1,0 +1,14 @@
+import * as vscode from 'vscode';
+import { SyntaxTree } from "../AL Code Outline/syntaxTree";
+import { ALFullSyntaxTreeNode } from '../AL Code Outline/alFullSyntaxTreeNode';
+import { FullSyntaxTreeNodeKind } from './fullSyntaxTreeNodeKind';
+
+export class SyntaxTreeExt {
+    private constructor() {
+
+    }
+    static getMethodOrTriggerTreeNodeOfCurrentPosition(syntaxTree: SyntaxTree, position: vscode.Position): ALFullSyntaxTreeNode | undefined {
+        let methodOrTriggerTreeNode: ALFullSyntaxTreeNode | undefined = syntaxTree.findTreeNode(position, [FullSyntaxTreeNodeKind.getMethodDeclaration(), FullSyntaxTreeNodeKind.getTriggerDeclaration()]);
+        return methodOrTriggerTreeNode;
+    }
+}

--- a/src/extension/AL Code Outline Ext/syntaxTreeExt.ts
+++ b/src/extension/AL Code Outline Ext/syntaxTreeExt.ts
@@ -7,8 +7,24 @@ export class SyntaxTreeExt {
     private constructor() {
 
     }
+    
+    static getObjectTreeNode(syntaxTree: SyntaxTree, position: vscode.Position): ALFullSyntaxTreeNode | undefined {
+        let kinds: string[] = [
+            FullSyntaxTreeNodeKind.getTableObject(),
+            FullSyntaxTreeNodeKind.getTableExtensionObject(),
+            FullSyntaxTreeNodeKind.getPageObject(),
+            FullSyntaxTreeNodeKind.getPageExtensionObject(),
+            FullSyntaxTreeNodeKind.getCodeunitObject(),
+            FullSyntaxTreeNodeKind.getReportObject(),
+            FullSyntaxTreeNodeKind.getXmlPortObject()
+        ]
+        let objectTreeNode: ALFullSyntaxTreeNode | undefined = syntaxTree.findTreeNode(position, kinds);
+        return objectTreeNode;
+    }
+
     static getMethodOrTriggerTreeNodeOfCurrentPosition(syntaxTree: SyntaxTree, position: vscode.Position): ALFullSyntaxTreeNode | undefined {
         let methodOrTriggerTreeNode: ALFullSyntaxTreeNode | undefined = syntaxTree.findTreeNode(position, [FullSyntaxTreeNodeKind.getMethodDeclaration(), FullSyntaxTreeNodeKind.getTriggerDeclaration()]);
         return methodOrTriggerTreeNode;
     }
+
 }

--- a/src/extension/AL Code Outline Ext/textRangeExt.ts
+++ b/src/extension/AL Code Outline Ext/textRangeExt.ts
@@ -3,7 +3,8 @@ import { TextPositionExt } from './textPositionExt';
 
 export class TextRangeExt {
     public static createVSCodeRange(textRange: any): vscode.Range {
-        return new vscode.Range(textRange.start.line, textRange.start.character, textRange.end.line, textRange.end.character);
+        let vscodeRange: vscode.Range = new vscode.Range(textRange.start.line, textRange.start.character, textRange.end.line, textRange.end.character);
+        return vscodeRange;
     }
     public static insideVsRange(textRange: any, vsRange: vscode.Range): boolean {
         if (!textRange.start || !textRange.end) {

--- a/src/extension/alCreateProcedureCA.ts
+++ b/src/extension/alCreateProcedureCA.ts
@@ -26,7 +26,7 @@ export class ALCreateProcedureCA implements vscode.CodeActionProvider {
             return;
         }
 
-        if (!this.considerLine(document, range, diagnostic)) {
+        if (!await this.considerLine(document, range, diagnostic)) {
             return;
         }
 
@@ -45,19 +45,22 @@ export class ALCreateProcedureCA implements vscode.CodeActionProvider {
         }
     }
 
-    private considerLine(document: vscode.TextDocument, range: vscode.Range, diagnostic: vscode.Diagnostic): boolean {
+    private async considerLine(document: vscode.TextDocument, range: vscode.Range, diagnostic: vscode.Diagnostic): Promise<boolean> {
         let textLine = document.lineAt(diagnostic.range.end.line).text;
         if (textLine.length > diagnostic.range.end.character) {
             let nextCharacter = textLine.charAt(diagnostic.range.end.character);
-            if (nextCharacter === '(' && textLine.substr(diagnostic.range.end.character).includes(')')) {
-                return true;
+            if (nextCharacter === '(') {
+                let syntaxTree: SyntaxTree = await SyntaxTree.getInstance(document);
+                let invocationExpressionTreeNode: ALFullSyntaxTreeNode | undefined = syntaxTree.findTreeNode(range.start, [FullSyntaxTreeNodeKind.getInvocationExpression()]);
+                if (invocationExpressionTreeNode) {
+                    return true;
+                }
             }
         }
         return false;
     }
 
     public async createProcedureObject(document: vscode.TextDocument, diagnostic: vscode.Diagnostic): Promise<ALProcedure | undefined> {
-        let rangeOfProcedureCall = new ALSourceCodeHandler(document).expandRangeToRangeOfProcedureCall(diagnostic.range);
         let syntaxTree: SyntaxTree = await SyntaxTree.getInstance(document);
         let invocationExpressionTreeNode: ALFullSyntaxTreeNode | undefined = syntaxTree.findTreeNode(diagnostic.range.start, [FullSyntaxTreeNodeKind.getInvocationExpression()]);
         if (isUndefined(invocationExpressionTreeNode)) {

--- a/src/extension/alCreateProcedureCA.ts
+++ b/src/extension/alCreateProcedureCA.ts
@@ -9,6 +9,9 @@ import { RenameMgt } from './checkRename';
 import { ALCodeOutlineExtension } from './devToolsExtensionContext';
 import { ToolsGetSyntaxTreeSymbolsRequest } from './ToolsGetSyntaxTreeSymbolsRequest';
 import { ToolsGetSyntaxTreeRequest } from './toolsGetSyntaxTreeRequest';
+import { SyntaxTree } from './AL Code Outline/syntaxTree';
+import { FullSyntaxTreeNodeKind } from './AL Code Outline Ext/fullSyntaxTreeNodeKind';
+import { ALFullSyntaxTreeNode } from './AL Code Outline/alFullSyntaxTreeNode';
 
 export class ALCreateProcedureCA implements vscode.CodeActionProvider {
 
@@ -55,10 +58,12 @@ export class ALCreateProcedureCA implements vscode.CodeActionProvider {
 
     public async createProcedureObject(document: vscode.TextDocument, diagnostic: vscode.Diagnostic): Promise<ALProcedure | undefined> {
         let rangeOfProcedureCall = new ALSourceCodeHandler(document).expandRangeToRangeOfProcedureCall(diagnostic.range);
-        if (isUndefined(rangeOfProcedureCall)) {
+        let syntaxTree: SyntaxTree = await SyntaxTree.getInstance(document);
+        let invocationExpressionTreeNode: ALFullSyntaxTreeNode | undefined = syntaxTree.findTreeNode(diagnostic.range.start, [FullSyntaxTreeNodeKind.getInvocationExpression()]);
+        if (isUndefined(invocationExpressionTreeNode)) {
             return;
         } else {
-            let alProcedureCreator = new ALProcedureCallParser(document, rangeOfProcedureCall, diagnostic);
+            let alProcedureCreator = new ALProcedureCallParser(document, diagnostic);
             await alProcedureCreator.initialize();
             let procedureToCreate = await alProcedureCreator.getProcedure();
             return procedureToCreate;

--- a/src/extension/alExtractToProcedureCA.ts
+++ b/src/extension/alExtractToProcedureCA.ts
@@ -5,7 +5,6 @@ import { ALProcedureSourceCodeCreator } from './alProcedureSourceCodeCreator';
 import { ALSourceCodeHandler } from './alSourceCodeHandler';
 import { ALCodeOutlineExtension } from './devToolsExtensionContext';
 import { DocumentUtils } from './documentUtils';
-import { ALSymbolHandler } from './alSymbolHandler';
 import { ALVariable } from './alVariable';
 import { ALVariableParser } from './alVariableParser';
 import { ALObject } from './alObject';
@@ -17,12 +16,14 @@ import { TextRangeExt } from './AL Code Outline Ext/textRangeExt';
 import { FullSyntaxTreeNodeKind } from './AL Code Outline Ext/fullSyntaxTreeNodeKind';
 import { RangeAnalzyer } from './Extract Procedure/rangeAnalyzer';
 import { ReturnTypeAnalzyer } from './Extract Procedure/returnTypeAnalyzer';
+import { SyntaxTreeExt } from './AL Code Outline Ext/syntaxTreeExt';
+import { ALParameterParser } from './alParameterParser';
+import { ALObjectParser } from './alObjectParser';
 
 export class ALExtractToProcedureCA implements vscode.CodeActionProvider {
     static async renameMethod(): Promise<any> {
         let editor = vscode.window.activeTextEditor;
         if (editor) {
-            let rangeToCursor: vscode.Range = new vscode.Range(editor.selection.start.line, 0, editor.selection.start.line, editor.selection.start.character);
             let newProcedureCharacterPos: number = editor.document.lineAt(editor.selection.start.line).text.indexOf(RenameMgt.newProcedureName + '(');
             let posOfProcedureCall = new vscode.Position(editor.selection.start.line, newProcedureCharacterPos);
 
@@ -62,66 +63,100 @@ export class ALExtractToProcedureCA implements vscode.CodeActionProvider {
         }
     }
     public async provideProcedureObjectForCodeAction(document: vscode.TextDocument, rangeExpanded: vscode.Range, returnTypeAnalyzer: ReturnTypeAnalzyer): Promise<ALProcedure | undefined> {
+        let syntaxTree: SyntaxTree = await SyntaxTree.getInstance(document);
+        let procedureOrTriggerTreeNode: ALFullSyntaxTreeNode | undefined = SyntaxTreeExt.getMethodOrTriggerTreeNodeOfCurrentPosition(syntaxTree, rangeExpanded.start);
+        if (!procedureOrTriggerTreeNode) {
+            return;
+        }
+        let localVariableTreeNodes: ALFullSyntaxTreeNode[] = this.getLocalVariablesOfTreeNode(procedureOrTriggerTreeNode);
+        let parameterTreeNodes: ALFullSyntaxTreeNode[] = this.getParametersOfTreeNode(procedureOrTriggerTreeNode);
+        let returnVariableTreeNode: ALFullSyntaxTreeNode | undefined = this.getReturnVariableOfTreeNode(procedureOrTriggerTreeNode);
 
-        let procedureOrTrigger: any = await this.getCurrentProcedureOrTriggerSymbol(document, rangeExpanded.start);
-        let localVariables: any[] = this.getLocalVariables(procedureOrTrigger);
-        let parameters: any[] = this.getParameters(procedureOrTrigger);
 
-        let variablesNeeded: any[] = await this.getVariablesNeededInNewProcedure(localVariables, document, rangeExpanded);
-        let parametersNeeded: any[] = await this.getParametersNeededInNewProcedure(parameters, document, rangeExpanded);
+        let variablesNeeded: ALFullSyntaxTreeNode[] = await this.getALVariablesNeededInNewProcedure(localVariableTreeNodes, document, rangeExpanded);
+        let parametersNeeded: ALFullSyntaxTreeNode[] = await this.getParametersNeededInNewProcedure(parameterTreeNodes, document, rangeExpanded);
+        let returnVariableNeeded: ALFullSyntaxTreeNode | undefined = await this.getReturnVariableNeeded(returnVariableTreeNode, document, rangeExpanded);
         //>>>temporary fix because of bug in al language
-        if (procedureOrTrigger.kind === 236) {
-            parametersNeeded = await this.getParametersNeededInNewProcedure_TriggerBugFix(parameters, document, rangeExpanded, parametersNeeded);
+        //Show References of Parameter declared in triggers is not working.
+        if (procedureOrTriggerTreeNode.kind === FullSyntaxTreeNodeKind.getTriggerDeclaration()) {
+            parametersNeeded = await this.getParametersNeededInNewProcedure_TriggerBugFix(parameterTreeNodes, document, rangeExpanded, parametersNeeded);
         }
         //<<<
 
+        let variableTreeNodesWhichBecomeVarParameters: ALFullSyntaxTreeNode[] = await this.getVariablesWhichBecomeVarParameters(variablesNeeded, document, rangeExpanded);
+        let variableTreeNodesWhichBecomeNormalParameters: ALFullSyntaxTreeNode[] = this.getVariablesWhichBecomeNormalParameters();
+        let variableTreeNodesWhichStayLocalVariables: ALFullSyntaxTreeNode[] = this.getVariablesWhichStayLocalVariables(variablesNeeded, variableTreeNodesWhichBecomeVarParameters, variableTreeNodesWhichBecomeNormalParameters);
 
-        let variablesWhichBecomeVarParameters: any[] = await this.getVariablesWhichBecomeVarParameters(variablesNeeded, procedureOrTrigger, document, rangeExpanded);
-        let variablesWhichBecomeNormalParameters: any[] = this.getVariablesWhichBecomeNormalParameters(variablesNeeded, procedureOrTrigger, document, rangeExpanded);
-        let variablesWhichStayLocalVariables: any[] = this.getVariablesWhichStayLocalVariables(variablesNeeded, variablesWhichBecomeVarParameters, variablesWhichBecomeNormalParameters);
+        let parameterTreeNodesWhichBecomeVarParameters: ALFullSyntaxTreeNode[] = this.getParametersWhichBecomeVarParameters(parametersNeeded);
+        let parameterTreeNodesWhichBecomeNormalParameters: ALFullSyntaxTreeNode[] = this.getParametersWhichBecomeNormalParameters();
 
-        let parametersWhichBecomeVarParameters: any[] = this.getParametersWhichBecomeVarParameters(parametersNeeded, procedureOrTrigger, document, rangeExpanded);
-        let parametersWhichBecomeNormalParameters: any[] = this.getParametersWhichBecomeNormalParameters(parametersNeeded, parametersWhichBecomeVarParameters);
+        let returnVariableTreeNodeWhichBecomesVarParameter: ALFullSyntaxTreeNode | undefined = this.getReturnVariableWhichBecomesVarParameter(returnVariableNeeded);
+        //Codeunit onRun Trigger implicitly has a Rec Variable which is declared nowhere
+        let typeOfRecWhichBecomesVarParameter: string | undefined = await this.getSourceTableTypeOfCodeunitOnRunTrigger(document, rangeExpanded);
 
         let procedureToCreate: ALProcedure | undefined;
         procedureToCreate = await this.createProcedureObject(document, rangeExpanded,
-            variablesWhichBecomeVarParameters,
-            variablesWhichBecomeNormalParameters,
-            variablesWhichStayLocalVariables,
-            parametersWhichBecomeVarParameters,
-            parametersWhichBecomeNormalParameters,
+            variableTreeNodesWhichBecomeVarParameters,
+            variableTreeNodesWhichBecomeNormalParameters,
+            variableTreeNodesWhichStayLocalVariables,
+            parameterTreeNodesWhichBecomeVarParameters,
+            parameterTreeNodesWhichBecomeNormalParameters,
+            returnVariableTreeNodeWhichBecomesVarParameter,
+            typeOfRecWhichBecomesVarParameter,
             returnTypeAnalyzer);
 
         return procedureToCreate;
     }
+    getReturnVariableWhichBecomesVarParameter(returnVariableTreeNode: ALFullSyntaxTreeNode | undefined): ALFullSyntaxTreeNode | undefined {
+        return returnVariableTreeNode;
+    }
 
-    async createProcedureObject(document: vscode.TextDocument, rangeExpanded: vscode.Range, variablesWhichBecomeVarParameters: any[], variablesWhichBecomeNormalParameters: any[], variablesWhichStayLocalVariables: any[], parametersWhichBecomeVarParameters: any[], parametersWhichBecomeNormalParameters: any[], returnTypeAnalyzer: ReturnTypeAnalzyer): Promise<ALProcedure | undefined> {
+    async createProcedureObject(document: vscode.TextDocument, rangeExpanded: vscode.Range, variableTreeNodesWhichBecomeVarParameters: ALFullSyntaxTreeNode[], variableTreeNodesWhichBecomeNormalParameters: ALFullSyntaxTreeNode[], variableTreeNodesWhichStayLocalVariables: ALFullSyntaxTreeNode[], parametersWhichBecomeVarParameters: ALFullSyntaxTreeNode[], parametersWhichBecomeNormalParameters: ALFullSyntaxTreeNode[], returnVariableWhichBecomesVarParameter: ALFullSyntaxTreeNode | undefined, typeOfRecWhichBecomesVarParameter: string | undefined, returnTypeAnalyzer: ReturnTypeAnalzyer): Promise<ALProcedure | undefined> {
         let procedure: ALProcedure;
         let parameters: ALVariable[] = [];
         let variables: ALVariable[] = [];
-        parametersWhichBecomeNormalParameters.forEach(parameterSymbol => { parameters.push(ALVariableParser.parseParameterSymbolToALVariable(parameterSymbol)); });
-        parametersWhichBecomeVarParameters.forEach(parameterSymbol => {
-            let alVariable: ALVariable = ALVariableParser.parseParameterSymbolToALVariable(parameterSymbol);
+
+        //Codeunit onRun Trigger implicitly has a Rec Variable which is declared nowhere
+        if (typeOfRecWhichBecomesVarParameter) {
+            parameters.push(new ALVariable('Rec', 'OnRun', true, typeOfRecWhichBecomesVarParameter));
+        }
+
+        for (let i = 0; i < parametersWhichBecomeNormalParameters.length; i++) {
+            parameters.push(await ALParameterParser.parseParameterTreeNodeToALVariable(document, parametersWhichBecomeNormalParameters[i]));
+        }
+        for (let i = 0; i < parametersWhichBecomeVarParameters.length; i++) {
+            let alVariable: ALVariable = await ALParameterParser.parseParameterTreeNodeToALVariable(document, parametersWhichBecomeVarParameters[i]);
             alVariable.isVar = true;
             parameters.push(alVariable);
+        }
+
+        let alVariablesWhichBecomveVarParameters: ALVariable[] = await ALVariableParser.parseVariableTreeNodeArrayToALVariableArray(document, variableTreeNodesWhichBecomeVarParameters);
+        alVariablesWhichBecomveVarParameters.forEach(variable => {
+            variable.isVar = true;
+            parameters.push(variable);
         });
-
-        // Rec
-        let procedureOrTrigger: any = await this.getCurrentProcedureOrTriggerSymbol(document, rangeExpanded.start);
-        await this.addRecParameterInCodeunitOnRunTrigger(procedureOrTrigger, document, rangeExpanded, parameters);
-
-        variablesWhichBecomeVarParameters.forEach(variableSymbol => {
-            let alVariable: ALVariable = ALVariableParser.parseVariableSymbolToALVariable(variableSymbol);
+        let alVariablesWhichBecomeNormalParameters: ALVariable[] = await ALVariableParser.parseVariableTreeNodeArrayToALVariableArray(document, variableTreeNodesWhichBecomeNormalParameters);
+        alVariablesWhichBecomeNormalParameters.forEach(variable => {
+            parameters.push(variable);
+        });
+        let alVariablesWhichStayLocalVariables: ALVariable[] = await ALVariableParser.parseVariableTreeNodeArrayToALVariableArray(document, variableTreeNodesWhichStayLocalVariables);
+        alVariablesWhichStayLocalVariables.forEach(variable => {
+            variables.push(variable);
+        });
+        if (returnVariableWhichBecomesVarParameter) {
+            let alVariable: ALVariable = await ALVariableParser.parseReturnValueTreeNodeToALVariable(document, returnVariableWhichBecomesVarParameter);
             alVariable.isVar = true;
             parameters.push(alVariable);
-        });
-        variablesWhichBecomeNormalParameters.forEach(variableSymbol => parameters.push(ALVariableParser.parseVariableSymbolToALVariable(variableSymbol)));
-        variablesWhichStayLocalVariables.forEach(variableSymbol => variables.push(ALVariableParser.parseVariableSymbolToALVariable(variableSymbol)));
+        }
 
         let returnType: string | undefined = returnTypeAnalyzer.getReturnType();
 
-        let alObjectSymbol = await ALCodeOutlineExtension.getFirstObjectSymbolOfDocumentUri(document.uri);
-        let alObject: ALObject = new ALObject(alObjectSymbol.name, alObjectSymbol.icon, alObjectSymbol.id, document.uri);
+        let syntaxTree: SyntaxTree = await SyntaxTree.getInstance(document);
+        let objectTreeNode: ALFullSyntaxTreeNode | undefined = SyntaxTreeExt.getObjectTreeNode(syntaxTree, rangeExpanded.start);
+        if (!objectTreeNode) {
+            throw new Error('Unable to find object tree node');
+        }
+        let alObject: ALObject = ALObjectParser.parseObjectTreeNodeToALObject(document, objectTreeNode);
         procedure = new ALProcedure(RenameMgt.newProcedureName, parameters, variables, returnType, true, alObject);
         let selectedText: string = document.getText(rangeExpanded).trim();
         if (returnType && returnTypeAnalyzer.getAddVariableToExtractedRange()) {
@@ -137,52 +172,43 @@ export class ALExtractToProcedureCA implements vscode.CodeActionProvider {
         procedure.setBody(selectedText);
         return procedure;
     }
-    getVariablesWhichStayLocalVariables(variablesNeeded: any[], variablesWhichBecomeVarParameters: any[], variablesWhichBecomeNormalParameters: any[]): any[] {
-        let variablesWhichStayLocal: ALVariable[] = variablesNeeded.filter(variable =>
+    getVariablesWhichStayLocalVariables(variablesNeeded: ALFullSyntaxTreeNode[], variablesWhichBecomeVarParameters: ALFullSyntaxTreeNode[], variablesWhichBecomeNormalParameters: ALFullSyntaxTreeNode[]): ALFullSyntaxTreeNode[] {
+        let variablesWhichStayLocal: ALFullSyntaxTreeNode[] = variablesNeeded.filter(variable =>
             !variablesWhichBecomeNormalParameters.includes(variable) &&
             !variablesWhichBecomeVarParameters.includes(variable));
         return variablesWhichStayLocal;
     }
-    getVariablesWhichBecomeNormalParameters(variablesNeeded: any[], procedureOrTrigger: any, document: vscode.TextDocument, rangeSelected: vscode.Range): any[] {
+    getVariablesWhichBecomeNormalParameters(): any[] {
         return [];
     }
-    async getVariablesWhichBecomeVarParameters(variablesNeeded: any[], procedureOrTrigger: any, document: vscode.TextDocument, rangeSelected: vscode.Range): Promise<any[]> {
-        let bodyTreeNode: ALFullSyntaxTreeNode | undefined = (await SyntaxTree.getInstance(document)).findTreeNode(rangeSelected.start, [FullSyntaxTreeNodeKind.getBlock()]);
+    async getVariablesWhichBecomeVarParameters(variablesNeeded: ALFullSyntaxTreeNode[], document: vscode.TextDocument, rangeSelected: vscode.Range): Promise<ALFullSyntaxTreeNode[]> {
+        let syntaxTree: SyntaxTree = await SyntaxTree.getInstance(document);
+        let bodyTreeNode: ALFullSyntaxTreeNode | undefined = syntaxTree.findTreeNode(rangeSelected.start, [FullSyntaxTreeNodeKind.getBlock()]);
         if (!bodyTreeNode || !bodyTreeNode?.fullSpan) {
             return variablesNeeded;
         }
-        let identifierNames: ALFullSyntaxTreeNode[] = [];
-        ALFullSyntaxTreeNodeExt.collectChildNodes(bodyTreeNode, FullSyntaxTreeNodeKind.getIdentifierName(), true, identifierNames);
+
         let bodyRangeOfProcedure: vscode.Range = TextRangeExt.createVSCodeRange(bodyTreeNode.fullSpan);
         let rangeBeforeSelection: vscode.Range = new vscode.Range(bodyRangeOfProcedure.start, rangeSelected.start);
         let rangeAfterSelection: vscode.Range = new vscode.Range(rangeSelected.end, bodyRangeOfProcedure.end);
 
         let variablesBecomingVarParameters: any[] = [];
         for (let i = 0; i < variablesNeeded.length; i++) {
-            let variable = variablesNeeded[i];
-            let isTemporary: boolean = false;
-            let isProcedureCallOnObject: boolean = false;
-            let isVarParameterOfOtherProcedurecall: boolean = false;
-            let isUsedOutsideSelectedRange: boolean = false;
-            // isTemporary = this.isSymbolTemporary(variable);
-
-            let positionVariableDeclaration = new vscode.Position(variable.selectionRange.start.line, variable.selectionRange.start.character);
-            let references: vscode.Location[] | undefined = await vscode.commands.executeCommand('vscode.executeReferenceProvider', document.uri, positionVariableDeclaration);
-            if (references && references.length > 0) {
-                for (let reference of references) {
-                    if (rangeBeforeSelection.contains(reference.range)) {
-                        isUsedOutsideSelectedRange = true;
-                        //     // TODO: If part of procedure call as var, then it has also to be a var-Parameter
-                        //     isVarParameterOfOtherProcedurecall = this.isVarParameterOfOtherProcedureCall(rangeBeforeSelection, reference.range, document);
-                        //     // If procedure call on this object, then the instance has to be handed over as var-Parameter as well.
-                        //     isProcedureCallOnObject = this.isProcedureCallOnObject(rangeBeforeSelection, reference.range, document);
-                    }
-                    if (rangeAfterSelection.contains(reference.range)) {
-                        isUsedOutsideSelectedRange = true;
-                    }
-                }
+            let variable: ALFullSyntaxTreeNode = variablesNeeded[i];
+            if (!variable.kind) {
+                continue;
             }
-            // if (isTemporary || isProcedureCallOnObject) {
+            let isUsedOutsideSelectedRange: boolean = false;
+
+            //variableDeclaration and variableDeclarationName behave the same here
+            let positionOfVariableDeclaration: vscode.Position = DocumentUtils.trimRange(document, TextRangeExt.createVSCodeRange(variable.fullSpan)).start;
+            if (await this.isOneOfReferencesInRange(document, positionOfVariableDeclaration, rangeBeforeSelection)) {
+                isUsedOutsideSelectedRange = true;
+            } else if (await this.isOneOfReferencesInRange(document, positionOfVariableDeclaration, rangeAfterSelection)) {
+                isUsedOutsideSelectedRange = true;
+            }
+            // TODO: If part of procedure call as var, then it has also to be a var-Parameter
+
             if (isUsedOutsideSelectedRange) {
                 variablesBecomingVarParameters.push(variable);
             }
@@ -190,57 +216,38 @@ export class ALExtractToProcedureCA implements vscode.CodeActionProvider {
 
         return variablesBecomingVarParameters;
     }
-    getParametersWhichBecomeNormalParameters(parametersNeeded: any[], parametersWhichBecomeVarParameters: any[]): any[] {
+    getParametersWhichBecomeNormalParameters(): ALFullSyntaxTreeNode[] {
         return [];
     }
-    getParametersWhichBecomeVarParameters(parametersNeeded: any[], procedureOrTrigger: any, document: vscode.TextDocument, rangeSelected: vscode.Range): any[] {
+    getParametersWhichBecomeVarParameters(parametersNeeded: ALFullSyntaxTreeNode[]): ALFullSyntaxTreeNode[] {
         return parametersNeeded;
     }
-    private async addRecParameterInCodeunitOnRunTrigger(procedureOrTrigger: any, document: vscode.TextDocument, rangeExpanded: vscode.Range, parameters: ALVariable[]) {
-        if (procedureOrTrigger.kind === 236 && procedureOrTrigger.name.toLowerCase() === 'onrun') {
+    private async getSourceTableTypeOfCodeunitOnRunTrigger(document: vscode.TextDocument, rangeExpanded: vscode.Range): Promise<string | undefined> {
+        let textOfSelectedRange: string = document.getText(rangeExpanded);
+        if (textOfSelectedRange.match(/\bRec\b/)) {
             let syntaxTree: SyntaxTree = await SyntaxTree.getInstance(document);
-            let cuObjects: ALFullSyntaxTreeNode[] = syntaxTree.collectNodesOfKindXInWholeDocument(FullSyntaxTreeNodeKind.getCodeunitObject());
-            if (cuObjects.length === 1) {
-                let cuObject: ALFullSyntaxTreeNode = cuObjects[0];
-                let valueOfPropertyTreeNode: ALFullSyntaxTreeNode | undefined = ALFullSyntaxTreeNodeExt.getValueOfPropertyName(cuObject, 'TableNo');
-                if (valueOfPropertyTreeNode) {
-                    let rangeOfTableNo: vscode.Range = TextRangeExt.createVSCodeRange(valueOfPropertyTreeNode.fullSpan);
-                    let type = 'Record ' + document.getText(rangeOfTableNo);
-                    if (document.getText(rangeExpanded).includes('Rec')) {
-                        parameters.push(new ALVariable('Rec', procedureOrTrigger.name, true, type));
+            let methodOrTriggerTreeNode: ALFullSyntaxTreeNode | undefined = SyntaxTreeExt.getMethodOrTriggerTreeNodeOfCurrentPosition(syntaxTree, rangeExpanded.start);
+            if (methodOrTriggerTreeNode && methodOrTriggerTreeNode.kind === FullSyntaxTreeNodeKind.getTriggerDeclaration()) {
+                let identifierTreeNode: ALFullSyntaxTreeNode | undefined = ALFullSyntaxTreeNodeExt.getFirstChildNodeOfKind(methodOrTriggerTreeNode, FullSyntaxTreeNodeKind.getIdentifierName(), false);
+                if (identifierTreeNode && identifierTreeNode.name && identifierTreeNode.name.toLowerCase() === 'onrun') {
+                    let cuObjects: ALFullSyntaxTreeNode[] = syntaxTree.collectNodesOfKindXInWholeDocument(FullSyntaxTreeNodeKind.getCodeunitObject());
+                    if (cuObjects.length === 1) {
+                        let cuObject: ALFullSyntaxTreeNode = cuObjects[0];
+                        let valueOfPropertyTreeNode: ALFullSyntaxTreeNode | undefined = ALFullSyntaxTreeNodeExt.getValueOfPropertyName(cuObject, 'TableNo');
+                        if (valueOfPropertyTreeNode) {
+                            let rangeOfTableNo: vscode.Range = TextRangeExt.createVSCodeRange(valueOfPropertyTreeNode.fullSpan);
+                            let type = 'Record ' + document.getText(rangeOfTableNo);
+                            return type;
+                        }
                     }
                 }
             }
         }
+        return undefined;
     }
 
 
-    isVarParameterOfOtherProcedureCall(rangeBeforeSelection: vscode.Range, referenceRange: vscode.Range, document: vscode.TextDocument): boolean {
-        let isInQuotes: boolean = DocumentUtils.isPositionInQuotes(document, rangeBeforeSelection, referenceRange.start);
-        let isInProcedureCall: boolean = DocumentUtils.isPositionInProcedurecall(document, rangeBeforeSelection, referenceRange.start);
-        let openingBracketPosition: vscode.Position = DocumentUtils.getPreviousValidPositionOfCharacter(document, rangeBeforeSelection, referenceRange.start, '(');
-        return false;
-    }
-    private isSymbolTemporary(variable: any): boolean {
-        let subtype: string = variable.subtype;
-        return subtype.includes('temporary');
-    }
-    private isProcedureCallOnObject(rangeBeforeSelection: vscode.Range, referenceRange: vscode.Range, document: vscode.TextDocument) {
-        let afterDotPosition: vscode.Position = referenceRange.end.translate(0, 1);
-        let nextCharacter = document.getText(new vscode.Range(referenceRange.end, afterDotPosition));
-        if (nextCharacter === '.') {
-            let procedureNameRange = DocumentUtils.getNextWordRangeInsideLine(document, rangeBeforeSelection, afterDotPosition);
-            if (procedureNameRange) {
-                let procedureName: string = document.getText(procedureNameRange);
-                let openingBracket = document.getText(new vscode.Range(procedureNameRange.end, procedureNameRange.end.translate(0, 1)));
-                if (openingBracket === '(') {
-                    let procedureSymbol: any = new ALSymbolHandler().findSymbol(document, procedureNameRange.start, procedureName);
-                    if (procedureSymbol) {
-                        return true;
-                    }
-                }
-            }
-        }
+    isVarParameterOfOtherProcedureCall(): boolean {
         return false;
     }
 
@@ -260,36 +267,45 @@ export class ALExtractToProcedureCA implements vscode.CodeActionProvider {
             return bodyRange;
         }
     }
-    async getParametersNeededInNewProcedure(parameters: any[], document: vscode.TextDocument, rangeSelected: vscode.Range): Promise<any[]> {
-        let parametersNeeded: any[] = [];
+    async getParametersNeededInNewProcedure(parameters: ALFullSyntaxTreeNode[], document: vscode.TextDocument, rangeSelected: vscode.Range): Promise<ALFullSyntaxTreeNode[]> {
+        let parametersNeeded: ALFullSyntaxTreeNode[] = [];
         for (let i = 0; i < parameters.length; i++) {
-            let parameter = parameters[i];
-            let position = new vscode.Position(parameter.selectionRange.start.line, parameter.selectionRange.start.character);
-            let references: vscode.Location[] | undefined = await vscode.commands.executeCommand('vscode.executeReferenceProvider', document.uri, position);
-            if (references && references.length > 0) {
-                for (let reference of references) {
-                    if (rangeSelected.contains(reference.range)) {
-                        parametersNeeded.push(parameter);
-                        break;
-                    }
-                }
+            let parameterTreeNode: ALFullSyntaxTreeNode = parameters[i];
+            let identifierTreeNode: ALFullSyntaxTreeNode | undefined = ALFullSyntaxTreeNodeExt.getFirstChildNodeOfKind(parameterTreeNode, FullSyntaxTreeNodeKind.getIdentifierName(), false);
+            if (!identifierTreeNode) {
+                continue;
+            }
+            let range: vscode.Range = DocumentUtils.trimRange(document, TextRangeExt.createVSCodeRange(identifierTreeNode.fullSpan));
+            if (await this.isOneOfReferencesInRange(document, range.start, rangeSelected)) {
+                parametersNeeded.push(parameterTreeNode);
             }
         }
         return parametersNeeded;
     }
-    private async getParametersNeededInNewProcedure_TriggerBugFix(parameters: any[], document: vscode.TextDocument, rangeExpanded: vscode.Range, parametersNeeded: any[]): Promise<any[]> {
+    private async getParametersNeededInNewProcedure_TriggerBugFix(parameters: ALFullSyntaxTreeNode[], document: vscode.TextDocument, rangeExpanded: vscode.Range, parametersNeeded: ALFullSyntaxTreeNode[]): Promise<ALFullSyntaxTreeNode[]> {
         for (let i = 0; i < parameters.length; i++) {
-            let parameter = parameters[i];
+            let parameterTreeNode: ALFullSyntaxTreeNode = parameters[i];
+            let identifierTreeNode: ALFullSyntaxTreeNode | undefined = ALFullSyntaxTreeNodeExt.getFirstChildNodeOfKind(parameterTreeNode, FullSyntaxTreeNodeKind.getIdentifierName(), false);
+            if (!identifierTreeNode) {
+                continue;
+            }
             for (let lineNo = rangeExpanded.start.line; lineNo <= rangeExpanded.end.line; lineNo++) {
                 let lineText: string = document.lineAt(lineNo).text;
-                let indexOfParameterName = lineText.search(new RegExp('\\b' + parameter.name + '\\b'));
+                if (lineNo === rangeExpanded.start.line && lineNo !== rangeExpanded.end.line) {
+                    lineText = lineText.substring(rangeExpanded.start.character);
+                } else if (lineNo === rangeExpanded.start.line && lineNo === rangeExpanded.end.line) {
+                    lineText = lineText.substring(rangeExpanded.start.character, rangeExpanded.end.character);
+                } else if (lineNo === rangeExpanded.end.line) {
+                    lineText = lineText.substring(0, rangeExpanded.end.character);
+                }
+                let indexOfParameterName = lineText.search(new RegExp('\\b' + identifierTreeNode.name + '\\b','i'));
                 if (indexOfParameterName > 0) {
                     let locations: vscode.Location[] | undefined = await vscode.commands.executeCommand('vscode.executeDefinitionProvider', document.uri, new vscode.Position(lineNo, indexOfParameterName));
                     if (locations && locations.length > 0) {
                         let location = locations[0];
-                        let paramterRange: vscode.Range = TextRangeExt.createVSCodeRange(parameter.range);
-                        if (paramterRange.contains(location.range)) {
-                            parametersNeeded.push(parameter);
+                        let parameterRange: vscode.Range = TextRangeExt.createVSCodeRange(parameterTreeNode.fullSpan);
+                        if (parameterRange.contains(location.range)) {
+                            parametersNeeded.push(parameterTreeNode);
                             break;
                         }
                     }
@@ -298,22 +314,52 @@ export class ALExtractToProcedureCA implements vscode.CodeActionProvider {
         }
         return parametersNeeded;
     }
-    async getVariablesNeededInNewProcedure(localVariables: any[], document: vscode.TextDocument, rangeSelected: vscode.Range): Promise<any[]> {
-        let variablesNeeded: any[] = [];
-        for (let i = 0; i < localVariables.length; i++) {
-            let localVariable = localVariables[i];
-            let position = new vscode.Position(localVariable.selectionRange.start.line, localVariable.selectionRange.start.character);
-            let references: vscode.Location[] | undefined = await vscode.commands.executeCommand('vscode.executeReferenceProvider', document.uri, position);
-            if (references && references.length > 0) {
-                for (let reference of references) {
-                    if (rangeSelected.contains(reference.range)) {
+    async getALVariablesNeededInNewProcedure(localVariableTreeNodes: ALFullSyntaxTreeNode[], document: vscode.TextDocument, rangeSelected: vscode.Range): Promise<ALFullSyntaxTreeNode[]> {
+        let variablesNeeded: ALFullSyntaxTreeNode[] = [];
+        for (let i = 0; i < localVariableTreeNodes.length; i++) {
+            let localVariable: ALFullSyntaxTreeNode = localVariableTreeNodes[i];
+            if (!localVariable.kind) { continue; }
+
+            switch (localVariable.kind) {
+                case FullSyntaxTreeNodeKind.getVariableDeclaration():
+                    let range: vscode.Range = DocumentUtils.trimRange(document, TextRangeExt.createVSCodeRange(localVariable.fullSpan));
+                    if (await this.isOneOfReferencesInRange(document, range.start, rangeSelected)) {
                         variablesNeeded.push(localVariable);
-                        break;
                     }
-                }
+                    break;
+                case FullSyntaxTreeNodeKind.getVariableListDeclaration():
+                    let variableDeclarationNames: ALFullSyntaxTreeNode[] = [];
+                    ALFullSyntaxTreeNodeExt.collectChildNodes(localVariable, FullSyntaxTreeNodeKind.getVariableDeclarationName(), false, variableDeclarationNames);
+                    for (let x = 0; x < variableDeclarationNames.length; x++) {
+                        let range: vscode.Range = DocumentUtils.trimRange(document, TextRangeExt.createVSCodeRange(variableDeclarationNames[x].fullSpan));
+                        if (await this.isOneOfReferencesInRange(document, range.start, rangeSelected)) {
+                            variablesNeeded.push(variableDeclarationNames[i]);
+                        }
+                    }
+                    break;
             }
         }
         return variablesNeeded;
+    }
+    async getReturnVariableNeeded(returnVariableTreeNode: ALFullSyntaxTreeNode | undefined, document: vscode.TextDocument, rangeExpanded: vscode.Range): Promise<ALFullSyntaxTreeNode | undefined> {
+        if (returnVariableTreeNode && returnVariableTreeNode.childNodes) {
+            let rangeOfIdentifier = DocumentUtils.trimRange(document, TextRangeExt.createVSCodeRange(returnVariableTreeNode.childNodes[0].fullSpan));
+            if (await this.isOneOfReferencesInRange(document, rangeOfIdentifier.start, rangeExpanded)) {
+                return returnVariableTreeNode;
+            }
+        }
+        return undefined;
+    }
+    private async isOneOfReferencesInRange(document: vscode.TextDocument, positionToCallReference: vscode.Position, rangeToCheck: vscode.Range): Promise<boolean> {
+        let references: vscode.Location[] | undefined = await vscode.commands.executeCommand('vscode.executeReferenceProvider', document.uri, positionToCallReference);
+        if (references && references.length > 0) {
+            for (let reference of references) {
+                if (rangeToCheck.contains(reference.range)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
     getParameters(procedureOrTrigger: any): any[] {
         let parameters: any[] = [];
@@ -330,6 +376,32 @@ export class ALExtractToProcedureCA implements vscode.CodeActionProvider {
             localVariables = [];
         }
         return localVariables;
+    }
+    private getLocalVariablesOfTreeNode(procedureOrTriggerTreeNode: ALFullSyntaxTreeNode): ALFullSyntaxTreeNode[] {
+        let variableDeclarations: ALFullSyntaxTreeNode[] = [];
+        let varSection: ALFullSyntaxTreeNode | undefined = ALFullSyntaxTreeNodeExt.getFirstChildNodeOfKind(procedureOrTriggerTreeNode, FullSyntaxTreeNodeKind.getVarSection(), false);
+        if (varSection) {
+            ALFullSyntaxTreeNodeExt.collectChildNodes(varSection, FullSyntaxTreeNodeKind.getVariableDeclaration(), false, variableDeclarations);
+            ALFullSyntaxTreeNodeExt.collectChildNodes(varSection, FullSyntaxTreeNodeKind.getVariableListDeclaration(), false, variableDeclarations);
+        }
+        return variableDeclarations;
+    }
+    private getParametersOfTreeNode(procedureOrTriggerTreeNode: ALFullSyntaxTreeNode): ALFullSyntaxTreeNode[] {
+        let parameters: ALFullSyntaxTreeNode[] = [];
+        let parameterListTreeNode: ALFullSyntaxTreeNode | undefined = ALFullSyntaxTreeNodeExt.getFirstChildNodeOfKind(procedureOrTriggerTreeNode, FullSyntaxTreeNodeKind.getParameterList(), false);
+        if (parameterListTreeNode) {
+            ALFullSyntaxTreeNodeExt.collectChildNodes(parameterListTreeNode, FullSyntaxTreeNodeKind.getParameter(), false, parameters);
+        }
+        return parameters;
+    }
+    private getReturnVariableOfTreeNode(procedureOrTriggerTreeNode: ALFullSyntaxTreeNode): ALFullSyntaxTreeNode | undefined {
+        let returnValue: ALFullSyntaxTreeNode | undefined = ALFullSyntaxTreeNodeExt.getFirstChildNodeOfKind(procedureOrTriggerTreeNode, FullSyntaxTreeNodeKind.getReturnValue(), false);
+        if (returnValue) {
+            if (returnValue.childNodes && returnValue.childNodes.length === 2) {
+                return returnValue;
+            }
+        }
+        return undefined;
     }
     async getCurrentProcedureOrTriggerSymbol(document: vscode.TextDocument, position: vscode.Position): Promise<any> {
         return await ALCodeOutlineExtension.getProcedureOrTriggerSymbolOfCurrentLine(document.uri, position.line);
@@ -363,7 +435,6 @@ export class ALExtractToProcedureCA implements vscode.CodeActionProvider {
         if (isUndefined(codeActionToCreateProcedure)) {
             return;
         } else {
-            codeActionToCreateProcedure.isPreferred = true;
             return codeActionToCreateProcedure;
         }
     }

--- a/src/extension/alExtractToProcedureCA.ts
+++ b/src/extension/alExtractToProcedureCA.ts
@@ -200,31 +200,20 @@ export class ALExtractToProcedureCA implements vscode.CodeActionProvider {
         if (procedureOrTrigger.kind === 236 && procedureOrTrigger.name.toLowerCase() === 'onrun') {
             let syntaxTree: SyntaxTree = await SyntaxTree.getInstance(document);
             let cuObjects: ALFullSyntaxTreeNode[] = syntaxTree.collectNodesOfKindXInWholeDocument(FullSyntaxTreeNodeKind.getCodeunitObject());
-            if (cuObjects) {
+            if (cuObjects.length === 1) {
                 let cuObject: ALFullSyntaxTreeNode = cuObjects[0];
-                let propertyLists: ALFullSyntaxTreeNode[] = [];
-                ALFullSyntaxTreeNodeExt.collectChildNodes(cuObject, FullSyntaxTreeNodeKind.getPropertyList(), false, propertyLists);
-                if (propertyLists.length === 1) {
-                    let propertyList: ALFullSyntaxTreeNode = propertyLists[0];
-                    let properties: ALFullSyntaxTreeNode[] = [];
-                    ALFullSyntaxTreeNodeExt.collectChildNodes(propertyList, FullSyntaxTreeNodeKind.getProperty(), false, properties);
-                    if (properties.length > 0) {
-                        let tableNoProperties: ALFullSyntaxTreeNode[] = properties.filter(property => property.name && property.name.trim().toLowerCase() === 'tableno');
-                        if (tableNoProperties.length > 0) {
-                            let tableNoProperty: ALFullSyntaxTreeNode = tableNoProperties[0];
-                            if (tableNoProperty.childNodes && tableNoProperty.childNodes.length === 2) {
-                                let rangeOfTableNo: vscode.Range = TextRangeExt.createVSCodeRange(tableNoProperty.childNodes[1].fullSpan);
-                                let type = 'Record ' + document.getText(rangeOfTableNo);
-                                if (document.getText(rangeExpanded).includes('Rec')) {
-                                    parameters.push(new ALVariable('Rec', procedureOrTrigger.name, true, type));
-                                }
-                            }
-                        }
+                let valueOfPropertyTreeNode: ALFullSyntaxTreeNode | undefined = ALFullSyntaxTreeNodeExt.getValueOfPropertyName(cuObject, 'TableNo');
+                if (valueOfPropertyTreeNode) {
+                    let rangeOfTableNo: vscode.Range = TextRangeExt.createVSCodeRange(valueOfPropertyTreeNode.fullSpan);
+                    let type = 'Record ' + document.getText(rangeOfTableNo);
+                    if (document.getText(rangeExpanded).includes('Rec')) {
+                        parameters.push(new ALVariable('Rec', procedureOrTrigger.name, true, type));
                     }
                 }
             }
         }
     }
+
 
     isVarParameterOfOtherProcedureCall(rangeBeforeSelection: vscode.Range, referenceRange: vscode.Range, document: vscode.TextDocument): boolean {
         let isInQuotes: boolean = DocumentUtils.isPositionInQuotes(document, rangeBeforeSelection, referenceRange.start);

--- a/src/extension/alObjectParser.ts
+++ b/src/extension/alObjectParser.ts
@@ -1,0 +1,55 @@
+import * as vscode from 'vscode';
+import { ALFullSyntaxTreeNode } from "./AL Code Outline/alFullSyntaxTreeNode";
+import { ALObject } from './alObject';
+import { ALFullSyntaxTreeNodeExt } from './AL Code Outline Ext/alFullSyntaxTreeNodeExt';
+import { FullSyntaxTreeNodeKind } from './AL Code Outline Ext/fullSyntaxTreeNodeKind';
+
+export class ALObjectParser {
+    private static objectKinds: string[] = [
+        FullSyntaxTreeNodeKind.getTableObject(),
+        FullSyntaxTreeNodeKind.getTableExtensionObject(),
+        FullSyntaxTreeNodeKind.getPageObject(),
+        FullSyntaxTreeNodeKind.getPageExtensionObject(),
+        FullSyntaxTreeNodeKind.getPageCustomizationObject(),
+        FullSyntaxTreeNodeKind.getReportObject(),
+        FullSyntaxTreeNodeKind.getCodeunitObject(),
+        FullSyntaxTreeNodeKind.getXmlPortObject(),
+        FullSyntaxTreeNodeKind.getEnumType(),
+        FullSyntaxTreeNodeKind.getEnumExtensionType(),
+        FullSyntaxTreeNodeKind.getInterface()
+    ];
+
+    public static parseObjectTreeNodeToALObject(document: vscode.TextDocument, objectTreeNode: ALFullSyntaxTreeNode): ALObject {
+        if (objectTreeNode.kind && this.objectKinds.includes(objectTreeNode.kind)) {
+            let objectType: string = this.getType(objectTreeNode.kind);
+            let objectId: number = this.getObjectId(objectTreeNode);
+            let objectName: string = this.getName(objectTreeNode);
+            return new ALObject(objectName, objectType, objectId, document.uri);
+        }
+        throw new Error('That\'s not an Object Tree Node.');
+    }
+    private static getType(kind: string): string {
+        if (kind.endsWith('Value')) {
+            return kind.substring(0, kind.length - 1 - 'Value'.length);
+        }
+        if (kind.endsWith('Object')) {
+            return kind.substring(0, kind.length - 1 - 'Object'.length);
+        }
+        return kind;
+    }
+    private static getObjectId(objectTreeNode: ALFullSyntaxTreeNode): number {
+        let objectIdTreeNode: ALFullSyntaxTreeNode | undefined = ALFullSyntaxTreeNodeExt.getFirstChildNodeOfKind(objectTreeNode, FullSyntaxTreeNodeKind.getObjectId(), false);
+        if (objectIdTreeNode && objectIdTreeNode.name) {
+            let objectIdString: string = objectIdTreeNode.name;
+            return +objectIdString;
+        }
+        return 0;
+    }
+    private static getName(objectTreeNode: ALFullSyntaxTreeNode): string {
+        let identifierTreeNode: ALFullSyntaxTreeNode | undefined = ALFullSyntaxTreeNodeExt.getFirstChildNodeOfKind(objectTreeNode, FullSyntaxTreeNodeKind.getIdentifierName(), false);
+        if (identifierTreeNode && identifierTreeNode.name) {
+            return identifierTreeNode.name;
+        }
+        return '';
+    }
+}

--- a/src/extension/alParameterParser.ts
+++ b/src/extension/alParameterParser.ts
@@ -3,6 +3,11 @@ import { ALVariable } from "./alVariable";
 import { ALVariableHandler } from "./alVariableHandler";
 import { ALVariableParser } from './alVariableParser';
 import { isUndefined } from 'util';
+import { SyntaxTree } from './AL Code Outline/syntaxTree';
+import { FullSyntaxTreeNodeKind } from './AL Code Outline Ext/fullSyntaxTreeNodeKind';
+import { ALFullSyntaxTreeNode } from './AL Code Outline/alFullSyntaxTreeNode';
+import { ALFullSyntaxTreeNodeExt } from './AL Code Outline Ext/alFullSyntaxTreeNodeExt';
+import { TextRangeExt } from './AL Code Outline Ext/textRangeExt';
 
 export class ALParameterParser {
     public static parseALVariableArrayToParameterDeclarationString(variableArray: ALVariable[]): string {
@@ -15,24 +20,32 @@ export class ALParameterParser {
         }
         return parameterString;
     }
-    public static async parseParameterCallRangeToALVariableArray(rangeOfParameterCall: vscode.Range, procedureSymbol: any, document: vscode.TextDocument): Promise<ALVariable[]> {
+    public static async createALVariableArrayOutOfArgumentListRange(rangeOfArgumentList: vscode.Range, document: vscode.TextDocument): Promise<ALVariable[]> {
         let variables: ALVariable[] = [];
-        let callString = document.getText(rangeOfParameterCall);
+        let callString = document.getText(rangeOfArgumentList);
         if (callString === "") {
             return variables;
         }
 
-        let parameterRanges: vscode.Range[] = this.getParameterRangeArrayOfCallRange(document, rangeOfParameterCall);
-        for (let i = 0; i < parameterRanges.length; i++) {
-            let parameter: string = document.getText(parameterRanges[i]);
-
-            let variable = ALVariableHandler.getALVariableByNameOfSymbol(parameter, procedureSymbol);
+        let argumentRanges: vscode.Range[] = await this.getArgumentRangeArrayOutOfArgumentListRange(document, rangeOfArgumentList);
+        let syntaxTree: SyntaxTree = await SyntaxTree.getInstance(document);
+        let methodOrTriggerTreeNode: ALFullSyntaxTreeNode | undefined;
+        if (argumentRanges.length > 0) {
+            methodOrTriggerTreeNode = syntaxTree.findTreeNode(argumentRanges[0].start, [FullSyntaxTreeNodeKind.getMethodDeclaration(), FullSyntaxTreeNodeKind.getTriggerDeclaration()]);
+        }
+        for (let i = 0; i < argumentRanges.length; i++) {
+            let variable = await ALVariableHandler.getALVariableByName(document, argumentRanges[i]);
             if (isUndefined(variable)) {
-                let variableCall = parameter; //Customer."No." e.g.
-                variable = await ALVariableParser.parseVariableCallToALVariableUsingSymbols(document, parameterRanges[i]);
+                if (document.getText(argumentRanges[i]).trim().toLowerCase() === 'rec') {
+                    variable = await ALVariableHandler.getRecAsALVariable(document);
+                }
             }
             if (isUndefined(variable)) {
-                variable = ALVariableParser.parsePrimitiveTypes(document, parameterRanges[i]);
+                let variableCall = document.getText(argumentRanges[i]); //Customer."No." e.g.
+                variable = await ALVariableParser.parseMemberAccessExpressionToALVariableUsingSymbols(document, argumentRanges[i]);
+            }
+            if (isUndefined(variable)) {
+                variable = ALVariableParser.parsePrimitiveTypes(document, argumentRanges[i]);
             }
             if (isUndefined(variable)) {
                 variable = ALParameterParser.createVariantVariable();
@@ -43,7 +56,7 @@ export class ALParameterParser {
 
         return variables;
     }
-    static getParameterCallRangeOfDiagnostic(document: vscode.TextDocument, diagnostic: vscode.Diagnostic): vscode.Range {
+    static getArgumentListRangeOfDiagnostic(document: vscode.TextDocument, diagnostic: vscode.Diagnostic): vscode.Range {
         let line = document.lineAt(diagnostic.range.start.line).text;
         let chars: string[] = line.split('');
 
@@ -69,68 +82,81 @@ export class ALParameterParser {
         }
         throw new Error('Could not find parameters.');
     }
-    static getParameterRangeArrayOfCallRange(document: vscode.TextDocument, rangeOfParameterCall: vscode.Range): vscode.Range[] {
-        let parameterCallString = document.getText(rangeOfParameterCall);
-        let line = document.lineAt(rangeOfParameterCall.start.line).text;
-
-        let parameters: vscode.Range[] = [];
-        let nextParameterString: string = '';
-        let chars: string[] = line.split('');
-        let bracketDepth: number = 0;
-        let inQuotes: boolean = false;
-        let resetVariable: boolean = false;
-        let startPos: vscode.Position | undefined;
-        let endPos: vscode.Position | undefined;
-        let range: vscode.Range | undefined = document.getWordRangeAtPosition(rangeOfParameterCall.start);
-
-        for (let i = rangeOfParameterCall.start.character; i < rangeOfParameterCall.end.character; i++) {
-            if (chars[i] === '"') {
-                inQuotes = !inQuotes;
-            }
-            if (!inQuotes) {
-                if (chars[i] === '(') {
-                    bracketDepth += 1;
-                }
-                if (chars[i] === ')') {
-                    bracketDepth -= 1;
-                }
-                if (chars[i] === ',') {
-                    if (bracketDepth === 0) {
-                        resetVariable = true;
-                        nextParameterString = nextParameterString.trimRight();
-                        endPos = new vscode.Position(Number(startPos?.line), Number(startPos?.character) + nextParameterString.length);
-                        if (nextParameterString.length > 0) {
-                            parameters.push(new vscode.Range(startPos as vscode.Position, endPos as vscode.Position));
-                        }
-                    }
-                }
-            }
-
-            if (nextParameterString !== '' || chars[i] !== ' ') {
-                nextParameterString += chars[i];
-                if (!startPos) {
-                    startPos = new vscode.Position(rangeOfParameterCall.start.line, i);
-                }
-            }
-            if (resetVariable) {
-                resetVariable = false;
-                nextParameterString = '';
-                startPos = undefined;
-                endPos = undefined;
+    static async getArgumentRangeArrayOutOfArgumentListRange(document: vscode.TextDocument, rangeOfParameterCall: vscode.Range): Promise<vscode.Range[]> {
+        let vscodeRangeArr: vscode.Range[] = [];
+        let syntaxTree: SyntaxTree = await SyntaxTree.getInstance(document);
+        let invocationExpression: ALFullSyntaxTreeNode | undefined = syntaxTree.findTreeNode(rangeOfParameterCall.start, [FullSyntaxTreeNodeKind.getInvocationExpression()]);
+        if (invocationExpression) {
+            let argumentListTreeNode: ALFullSyntaxTreeNode | undefined = ALFullSyntaxTreeNodeExt.getFirstChildNodeOfKind(invocationExpression, FullSyntaxTreeNodeKind.getArgumentList(), false);
+            if (argumentListTreeNode && argumentListTreeNode.childNodes) {
+                let argumentList: ALFullSyntaxTreeNode[] = [];
+                argumentListTreeNode.childNodes.forEach(argumentTreeNode => {
+                    vscodeRangeArr.push(TextRangeExt.createVSCodeRange(argumentTreeNode.fullSpan));
+                });
             }
         }
-        nextParameterString = nextParameterString.trimRight();
-        if (nextParameterString.length > 0) {
-            endPos = new vscode.Position(Number(startPos?.line), Number(startPos?.character) + nextParameterString.length);
-            parameters.push(new vscode.Range(startPos as vscode.Position, endPos as vscode.Position));
-        }
+        return vscodeRangeArr;
+        // let parameterCallString = document.getText(rangeOfParameterCall);
+        // let line = document.lineAt(rangeOfParameterCall.start.line).text;
 
-        return parameters;
+        // let parameters: vscode.Range[] = [];
+        // let nextParameterString: string = '';
+        // let chars: string[] = line.split('');
+        // let bracketDepth: number = 0;
+        // let inQuotes: boolean = false;
+        // let resetVariable: boolean = false;
+        // let startPos: vscode.Position | undefined;
+        // let endPos: vscode.Position | undefined;
+        // let range: vscode.Range | undefined = document.getWordRangeAtPosition(rangeOfParameterCall.start);
+
+        // for (let i = rangeOfParameterCall.start.character; i < rangeOfParameterCall.end.character; i++) {
+        //     if (chars[i] === '"') {
+        //         inQuotes = !inQuotes;
+        //     }
+        //     if (!inQuotes) {
+        //         if (chars[i] === '(') {
+        //             bracketDepth += 1;
+        //         }
+        //         if (chars[i] === ')') {
+        //             bracketDepth -= 1;
+        //         }
+        //         if (chars[i] === ',') {
+        //             if (bracketDepth === 0) {
+        //                 resetVariable = true;
+        //                 nextParameterString = nextParameterString.trimRight();
+        //                 endPos = new vscode.Position(Number(startPos?.line), Number(startPos?.character) + nextParameterString.length);
+        //                 if (nextParameterString.length > 0) {
+        //                     parameters.push(new vscode.Range(startPos as vscode.Position, endPos as vscode.Position));
+        //                 }
+        //             }
+        //         }
+        //     }
+
+        //     if (nextParameterString !== '' || chars[i] !== ' ') {
+        //         nextParameterString += chars[i];
+        //         if (!startPos) {
+        //             startPos = new vscode.Position(rangeOfParameterCall.start.line, i);
+        //         }
+        //     }
+        //     if (resetVariable) {
+        //         resetVariable = false;
+        //         nextParameterString = '';
+        //         startPos = undefined;
+        //         endPos = undefined;
+        //     }
+        // }
+        // nextParameterString = nextParameterString.trimRight();
+        // if (nextParameterString.length > 0) {
+        //     endPos = new vscode.Position(Number(startPos?.line), Number(startPos?.character) + nextParameterString.length);
+        //     parameters.push(new vscode.Range(startPos as vscode.Position, endPos as vscode.Position));
+        // }
+
+        // return parameters;
     }
 
     private static createVariantVariable(): ALVariable {
         return new ALVariable("arg", undefined, false, 'Variant');
-        
+
     }
     public static getUniqueVariableName(variables: ALVariable[], newVariable: ALVariable): ALVariable {
         if (this.existsVariableNameWithNumber(variables, newVariable.name)) {

--- a/src/extension/alParameterParser.ts
+++ b/src/extension/alParameterParser.ts
@@ -1,13 +1,14 @@
 import * as vscode from 'vscode';
 import { ALVariable } from "./alVariable";
-import { ALVariableHandler } from "./alVariableHandler";
-import { ALVariableParser } from './alVariableParser';
 import { isUndefined } from 'util';
-import { SyntaxTree } from './AL Code Outline/syntaxTree';
 import { FullSyntaxTreeNodeKind } from './AL Code Outline Ext/fullSyntaxTreeNodeKind';
 import { ALFullSyntaxTreeNode } from './AL Code Outline/alFullSyntaxTreeNode';
 import { ALFullSyntaxTreeNodeExt } from './AL Code Outline Ext/alFullSyntaxTreeNodeExt';
 import { TextRangeExt } from './AL Code Outline Ext/textRangeExt';
+import { SyntaxTree } from './AL Code Outline/syntaxTree';
+import { SyntaxTreeExt } from './AL Code Outline Ext/syntaxTreeExt';
+import { TypeDetective } from './typeDetective';
+import { DocumentUtils } from './documentUtils';
 
 export class ALParameterParser {
     public static parseALVariableArrayToParameterDeclarationString(variableArray: ALVariable[]): string {
@@ -20,68 +21,48 @@ export class ALParameterParser {
         }
         return parameterString;
     }
-    public static async createALVariableArrayOutOfArgumentListRange(rangeOfArgumentList: vscode.Range, document: vscode.TextDocument): Promise<ALVariable[]> {
+    static async parseParameterTreeNodeToALVariable(document: vscode.TextDocument, parameterTreeNode: ALFullSyntaxTreeNode): Promise<ALVariable> {
+        if (!parameterTreeNode.kind || parameterTreeNode.kind !== FullSyntaxTreeNodeKind.getParameter()) {
+            throw new Error('That\'s not a parameter tree node.');
+        }
+        if (parameterTreeNode.childNodes) {
+            let identifierTreeNode: ALFullSyntaxTreeNode = parameterTreeNode.childNodes[0];
+            let rangeOfName: vscode.Range = DocumentUtils.trimRange(document, TextRangeExt.createVSCodeRange(identifierTreeNode.fullSpan));
+            let identifierName = document.getText(rangeOfName);
+            let typeTreeNode: ALFullSyntaxTreeNode = parameterTreeNode.childNodes[1];
+            let rangeOfType: vscode.Range = DocumentUtils.trimRange(document, TextRangeExt.createVSCodeRange(typeTreeNode.fullSpan));
+            let type = document.getText(rangeOfType);
+            let syntaxTree: SyntaxTree = await SyntaxTree.getInstance(document);
+            let methodOrTriggerTreeNode: ALFullSyntaxTreeNode | undefined = SyntaxTreeExt.getMethodOrTriggerTreeNodeOfCurrentPosition(syntaxTree, rangeOfType.start);
+            let rangeOfFullDeclaration: vscode.Range = DocumentUtils.trimRange(document, TextRangeExt.createVSCodeRange(parameterTreeNode.fullSpan));
+            let isVar: boolean = document.getText(rangeOfFullDeclaration).toLowerCase().startsWith('var');
+            return new ALVariable(identifierName, methodOrTriggerTreeNode?.name, isVar, type);
+        } else {
+            throw new Error('Variable declaration has no child nodes.');
+        }
+    }
+    public static async createALVariableArrayOutOfArgumentListTreeNode(argumentListTreeNode: ALFullSyntaxTreeNode, document: vscode.TextDocument): Promise<ALVariable[]> {
         let variables: ALVariable[] = [];
-        let callString = document.getText(rangeOfArgumentList);
-        if (callString === "") {
+        if (!argumentListTreeNode.childNodes) {
             return variables;
         }
 
-        let argumentRanges: vscode.Range[] = await this.getArgumentRangeArrayOutOfArgumentListRange(document, rangeOfArgumentList);
         let syntaxTree: SyntaxTree = await SyntaxTree.getInstance(document);
-        let methodOrTriggerTreeNode: ALFullSyntaxTreeNode | undefined;
-        if (argumentRanges.length > 0) {
-            methodOrTriggerTreeNode = syntaxTree.findTreeNode(argumentRanges[0].start, [FullSyntaxTreeNodeKind.getMethodDeclaration(), FullSyntaxTreeNodeKind.getTriggerDeclaration()]);
-        }
-        for (let i = 0; i < argumentRanges.length; i++) {
-            let variable = await ALVariableHandler.getALVariableByName(document, argumentRanges[i]);
-            if (isUndefined(variable)) {
-                let variableCall = document.getText(argumentRanges[i]); //Customer."No." e.g.
-                variable = await ALVariableParser.parseMemberAccessExpressionToALVariableUsingSymbols(document, argumentRanges[i]);
-            }
-            if (isUndefined(variable)) {
-                if (document.getText(argumentRanges[i]).trim().toLowerCase() === 'rec') {
-                    variable = await ALVariableHandler.getRecAsALVariable(document);
-                }
-            }
-            if (isUndefined(variable)) {
-                variable = ALVariableParser.parsePrimitiveTypes(document, argumentRanges[i]);
-            }
-            if (isUndefined(variable)) {
-                variable = ALParameterParser.createVariantVariable();
-            }
+        let methodOrTriggerTreeNode: ALFullSyntaxTreeNode | undefined = SyntaxTreeExt.getMethodOrTriggerTreeNodeOfCurrentPosition(syntaxTree, TextRangeExt.createVSCodeRange(argumentListTreeNode.fullSpan).start);
+        for (let i = 0; i < argumentListTreeNode.childNodes.length; i++) {
+            let typeDetective: TypeDetective = new TypeDetective(document, argumentListTreeNode.childNodes[i]);
+            await typeDetective.getTypeOfTreeNode();
+            let type: string = typeDetective.getType();
+            let name: string = typeDetective.getName();
+            let isVar: boolean = typeDetective.getIsVar() || typeDetective.getIsTemporary();
+            let variable: ALVariable = new ALVariable(name, methodOrTriggerTreeNode?.name, isVar, type);
             variable = ALParameterParser.getUniqueVariableName(variables, variable);
             variables.push(variable);
         }
 
         return variables;
     }
-    static getArgumentListRangeOfDiagnostic(document: vscode.TextDocument, diagnostic: vscode.Diagnostic): vscode.Range {
-        let line = document.lineAt(diagnostic.range.start.line).text;
-        let chars: string[] = line.split('');
 
-        let inQuotes: boolean = false;
-        let bracketDepth: number = 0;
-        let parameterStartPos: vscode.Position | undefined;
-        for (let i = diagnostic.range.end.character; i < line.length; i++) {
-            if (chars[i] === '"') {
-                inQuotes = !inQuotes;
-            } else if (!inQuotes) {
-                if (chars[i] === '(') {
-                    bracketDepth += 1;
-                    if (!parameterStartPos) {
-                        parameterStartPos = new vscode.Position(diagnostic.range.start.line, i + 1);
-                    }
-                } else if (chars[i] === ')') {
-                    bracketDepth -= 1;
-                    if (bracketDepth === 0) {
-                        return new vscode.Range(parameterStartPos as vscode.Position, new vscode.Position(diagnostic.range.start.line, i));
-                    }
-                }
-            }
-        }
-        throw new Error('Could not find parameters.');
-    }
     static async getArgumentRangeArrayOutOfArgumentListRange(document: vscode.TextDocument, rangeOfParameterCall: vscode.Range): Promise<vscode.Range[]> {
         let vscodeRangeArr: vscode.Range[] = [];
         let syntaxTree: SyntaxTree = await SyntaxTree.getInstance(document);
@@ -89,79 +70,18 @@ export class ALParameterParser {
         if (invocationExpression) {
             let argumentListTreeNode: ALFullSyntaxTreeNode | undefined = ALFullSyntaxTreeNodeExt.getFirstChildNodeOfKind(invocationExpression, FullSyntaxTreeNodeKind.getArgumentList(), false);
             if (argumentListTreeNode && argumentListTreeNode.childNodes) {
-                let argumentList: ALFullSyntaxTreeNode[] = [];
                 argumentListTreeNode.childNodes.forEach(argumentTreeNode => {
                     vscodeRangeArr.push(TextRangeExt.createVSCodeRange(argumentTreeNode.fullSpan));
                 });
             }
         }
         return vscodeRangeArr;
-        // let parameterCallString = document.getText(rangeOfParameterCall);
-        // let line = document.lineAt(rangeOfParameterCall.start.line).text;
-
-        // let parameters: vscode.Range[] = [];
-        // let nextParameterString: string = '';
-        // let chars: string[] = line.split('');
-        // let bracketDepth: number = 0;
-        // let inQuotes: boolean = false;
-        // let resetVariable: boolean = false;
-        // let startPos: vscode.Position | undefined;
-        // let endPos: vscode.Position | undefined;
-        // let range: vscode.Range | undefined = document.getWordRangeAtPosition(rangeOfParameterCall.start);
-
-        // for (let i = rangeOfParameterCall.start.character; i < rangeOfParameterCall.end.character; i++) {
-        //     if (chars[i] === '"') {
-        //         inQuotes = !inQuotes;
-        //     }
-        //     if (!inQuotes) {
-        //         if (chars[i] === '(') {
-        //             bracketDepth += 1;
-        //         }
-        //         if (chars[i] === ')') {
-        //             bracketDepth -= 1;
-        //         }
-        //         if (chars[i] === ',') {
-        //             if (bracketDepth === 0) {
-        //                 resetVariable = true;
-        //                 nextParameterString = nextParameterString.trimRight();
-        //                 endPos = new vscode.Position(Number(startPos?.line), Number(startPos?.character) + nextParameterString.length);
-        //                 if (nextParameterString.length > 0) {
-        //                     parameters.push(new vscode.Range(startPos as vscode.Position, endPos as vscode.Position));
-        //                 }
-        //             }
-        //         }
-        //     }
-
-        //     if (nextParameterString !== '' || chars[i] !== ' ') {
-        //         nextParameterString += chars[i];
-        //         if (!startPos) {
-        //             startPos = new vscode.Position(rangeOfParameterCall.start.line, i);
-        //         }
-        //     }
-        //     if (resetVariable) {
-        //         resetVariable = false;
-        //         nextParameterString = '';
-        //         startPos = undefined;
-        //         endPos = undefined;
-        //     }
-        // }
-        // nextParameterString = nextParameterString.trimRight();
-        // if (nextParameterString.length > 0) {
-        //     endPos = new vscode.Position(Number(startPos?.line), Number(startPos?.character) + nextParameterString.length);
-        //     parameters.push(new vscode.Range(startPos as vscode.Position, endPos as vscode.Position));
-        // }
-
-        // return parameters;
     }
 
-    private static createVariantVariable(): ALVariable {
-        return new ALVariable("arg", undefined, false, 'Variant');
-
-    }
     public static getUniqueVariableName(variables: ALVariable[], newVariable: ALVariable): ALVariable {
         if (this.existsVariableNameWithNumber(variables, newVariable.name)) {
             for (let i = 1; true; i++) {
-                let newVariableNameWithNumber = this.addNumberToVariableName(variables, newVariable.name, i);
+                let newVariableNameWithNumber = this.addNumberToVariableName(newVariable.name, i);
                 if (!this.existsVariableName(variables, newVariableNameWithNumber)) {
                     newVariable.name = newVariableNameWithNumber;
                     return newVariable;
@@ -170,8 +90,8 @@ export class ALParameterParser {
         } else {
             if (this.existsVariableName(variables, newVariable.name)) {
                 let existingVariable = variables.find(v => v.name === newVariable.name) as ALVariable;
-                existingVariable.name = this.addNumberToVariableName(variables, existingVariable.name, 1);
-                newVariable.name = this.addNumberToVariableName(variables, newVariable.name, 2);
+                existingVariable.name = this.addNumberToVariableName(existingVariable.name, 1);
+                newVariable.name = this.addNumberToVariableName(newVariable.name, 2);
                 return newVariable;
             } else {
                 return newVariable;
@@ -183,11 +103,11 @@ export class ALParameterParser {
         return !isUndefined(existingVariable);
     }
     static existsVariableNameWithNumber(variables: ALVariable[], variableName: string) {
-        variableName = this.addNumberToVariableName(variables, variableName);
+        variableName = this.addNumberToVariableName(variableName);
         let existingVariable = variables.find(v => v.name === variableName);
         return !isUndefined(existingVariable);
     }
-    private static addNumberToVariableName(variables: ALVariable[], variableName: string, number?: number): string {
+    private static addNumberToVariableName(variableName: string, number?: number): string {
         if (isUndefined(number)) {
             number = 1;
         }

--- a/src/extension/alProcedureCallParser.ts
+++ b/src/extension/alProcedureCallParser.ts
@@ -1,23 +1,21 @@
 import * as vscode from 'vscode';
 import { ALProcedure } from './alProcedure';
-import { ALVariableHandler } from './alVariableHandler';
 import { ALVariable } from './alVariable';
 import { ALParameterParser } from './alParameterParser';
 import { ALObject } from './alObject';
 import { SupportedDiagnosticCodes } from './supportedDiagnosticCodes';
 import { ALCodeOutlineExtension } from './devToolsExtensionContext';
-import { ALVariableParser } from './alVariableParser';
-import { ALSymbolHandler } from './alSymbolHandler';
 import { DocumentUtils } from './documentUtils';
 import { SyntaxTree } from './AL Code Outline/syntaxTree';
 import { ALFullSyntaxTreeNode } from './AL Code Outline/alFullSyntaxTreeNode';
 import { FullSyntaxTreeNodeKind } from './AL Code Outline Ext/fullSyntaxTreeNodeKind';
 import { TextRangeExt } from './AL Code Outline Ext/textRangeExt';
+import { TypeDetective } from './typeDetective';
+import { ALFullSyntaxTreeNodeExt } from './AL Code Outline Ext/alFullSyntaxTreeNodeExt';
 
 export class ALProcedureCallParser {
     private document: vscode.TextDocument;
     private diagnostic: vscode.Diagnostic;
-    private callingALObject?: ALObject;
     private calledALObject: ALObject | undefined;
     private calledProcedureName: string;
 
@@ -31,75 +29,11 @@ export class ALProcedureCallParser {
         this.calledALObject = new ALObject(calledObjectSymbol.name, calledObjectSymbol.icon, calledObjectSymbol.id, await this.getDocumentUriOfCalledObject());
 
         let callingObjectSymbol = await this.getCallingObjectSymbol();
-        this.callingALObject = new ALObject(callingObjectSymbol.name, callingObjectSymbol.icon, callingObjectSymbol.id, this.document.uri);
     }
 
     public async getProcedure(): Promise<ALProcedure | undefined> {
         let returnType: string | undefined;
         let parameters: ALVariable[];
-
-        let syntaxTree: SyntaxTree = await SyntaxTree.getInstance(this.document);
-        let invocationExpressionTreeNode: ALFullSyntaxTreeNode | undefined = syntaxTree.findTreeNode(this.diagnostic.range.start, [FullSyntaxTreeNodeKind.getInvocationExpression()]) as ALFullSyntaxTreeNode;
-        let invocationExpressionRange: vscode.Range = TextRangeExt.createVSCodeRange(invocationExpressionTreeNode.fullSpan);
-        let procedureCall: string = this.document.getText(invocationExpressionRange);
-
-        let assignmentStatementTreeNode: ALFullSyntaxTreeNode | undefined = syntaxTree.findTreeNode(invocationExpressionRange.start, [FullSyntaxTreeNodeKind.getAssignmentStatement(), FullSyntaxTreeNodeKind.getCompoundAssignmentStatement()]);
-        if (assignmentStatementTreeNode && assignmentStatementTreeNode.childNodes) {
-            let assignedTreeNode: ALFullSyntaxTreeNode = assignmentStatementTreeNode.childNodes[0];
-        }
-        let rangeOfReturnPart: vscode.Range | undefined;
-        let rangeOfProcedureCall: vscode.Range;
-        if (procedureCall.includes(':=')) {
-            rangeOfReturnPart = new vscode.Range(this.rangeOfWholeProcedureCall.start, new vscode.Position(this.rangeOfWholeProcedureCall.start.line, procedureCall.indexOf(':=') + this.rangeOfWholeProcedureCall.start.character));
-            let amountSpacesAtEnd: number = this.document.getText(rangeOfReturnPart).length - this.document.getText(rangeOfReturnPart).trimRight().length;
-            rangeOfReturnPart = new vscode.Range(rangeOfReturnPart.start, rangeOfReturnPart.end.translate(0, amountSpacesAtEnd * -1));
-            let rangeOfReturnPartText: string = this.document.getText(rangeOfReturnPart); //for debugging purposes
-            rangeOfProcedureCall = new vscode.Range(rangeOfReturnPart.end.translate(0, 2), this.rangeOfWholeProcedureCall.end);
-            let amountSpacesAtBeginning: number = this.document.getText(rangeOfProcedureCall).length - this.document.getText(rangeOfProcedureCall).trimLeft().length;
-            rangeOfProcedureCall = new vscode.Range(rangeOfProcedureCall.start.translate(0, amountSpacesAtBeginning), rangeOfProcedureCall.end);
-            let rangeOfProcedureCallText: string = this.document.getText(rangeOfProcedureCall); //for debugging purposes
-        } else {
-            rangeOfProcedureCall = this.rangeOfWholeProcedureCall;
-        }
-
-        if (rangeOfReturnPart) {
-            let wordRange: vscode.Range | undefined = DocumentUtils.getNextWordRangeInsideLine(this.document, this.rangeOfWholeProcedureCall);
-            if (wordRange) {
-                let rangeNextCharacter = new vscode.Range(wordRange.end, wordRange.end.translate(0, 1));
-                let textNextCharacter = this.document.getText(rangeNextCharacter);
-                if (this.document.getText(rangeNextCharacter) === '.') {
-                    let objectTextRange = wordRange;
-                    let fieldOrMethodTextRange = DocumentUtils.getNextWordRangeInsideLine(this.document, this.rangeOfWholeProcedureCall, objectTextRange.end);
-                    if (fieldOrMethodTextRange) {
-                        let alSymbolHandler: ALSymbolHandler = new ALSymbolHandler();
-                        let symbol = await alSymbolHandler.findSymbol(this.document, fieldOrMethodTextRange.start, this.document.getText(fieldOrMethodTextRange));
-                        if (symbol) {
-                            let uri: vscode.Uri = alSymbolHandler.getLastUri() as vscode.Uri;
-                            if (ALCodeOutlineExtension.isSymbolKindProcedureOrTrigger(symbol.kind)) {
-                                //TODO: Procedure as parameter: Get type of parameter
-                                // returnType =
-                            } else if (ALCodeOutlineExtension.isSymbolKindVariableOrParameter(symbol.kind)) {
-                                returnType = symbol.subtype;
-                            } else if (ALCodeOutlineExtension.isSymbolKindTableField(symbol.kind)) {
-                                returnType = (await ALVariableParser.parseFieldSymbolToALVariable(symbol, uri)).type;
-                            }
-                        }
-                    }
-                } else {
-                    //TODO: Procedure as parameter: Missing branch
-                    let alSymbolHandler: ALSymbolHandler = new ALSymbolHandler();
-                    let symbol = await alSymbolHandler.findSymbol(this.document, wordRange.start, this.document.getText(wordRange));
-                    if (symbol) {
-                        let uri: vscode.Uri = alSymbolHandler.getLastUri() as vscode.Uri;
-                        if (ALCodeOutlineExtension.isSymbolKindVariableOrParameter(symbol.kind)) {
-                            returnType = symbol.subtype;
-                        } else if (ALCodeOutlineExtension.isSymbolKindTableField(symbol.kind)) {
-                            returnType = (await ALVariableParser.parseFieldSymbolToALVariable(symbol, uri)).type;
-                        }
-                    }
-                }
-            }
-        }
 
         let isLocal: boolean;
         if (this.diagnostic.code?.toString() === SupportedDiagnosticCodes.AL0132.toString()) {
@@ -111,11 +45,79 @@ export class ALProcedureCallParser {
             isLocal = true;
         }
 
-        let argumentListRange: vscode.Range = ALParameterParser.getArgumentListRangeOfDiagnostic(this.document, this.diagnostic);
-        parameters = await this.createParametersOutOfArgumentListRange(argumentListRange, this.calledProcedureName);
+        let syntaxTree: SyntaxTree = await SyntaxTree.getInstance(this.document);
+        let invocationExpressionTreeNode: ALFullSyntaxTreeNode | undefined = syntaxTree.findTreeNode(this.diagnostic.range.start, [FullSyntaxTreeNodeKind.getInvocationExpression()]) as ALFullSyntaxTreeNode;
+        let invocationExpressionRange: vscode.Range = TextRangeExt.createVSCodeRange(invocationExpressionTreeNode.fullSpan);
+        invocationExpressionRange = DocumentUtils.trimRange(this.document, invocationExpressionRange);
+        
+        let argumentList: ALFullSyntaxTreeNode = ALFullSyntaxTreeNodeExt.getFirstChildNodeOfKind(invocationExpressionTreeNode, FullSyntaxTreeNodeKind.getArgumentList(), false) as ALFullSyntaxTreeNode;
+        parameters = await this.createParametersOutOfArgumentListTreeNode(argumentList, this.calledProcedureName);
+
+        returnType = await this.getReturnType(this.document, invocationExpressionRange);
 
         return new ALProcedure(this.calledProcedureName, parameters, [], returnType, isLocal, this.calledALObject as ALObject);
     }
+    private async getReturnType(document: vscode.TextDocument, range: vscode.Range): Promise<string | undefined> {
+        let syntaxTree: SyntaxTree = await SyntaxTree.getInstance(document);
+        let invocationExpressionTreeNode: ALFullSyntaxTreeNode = syntaxTree.findTreeNode(range.start, [FullSyntaxTreeNodeKind.getInvocationExpression()]) as ALFullSyntaxTreeNode;
+        while (invocationExpressionTreeNode.parentNode && invocationExpressionTreeNode.parentNode.kind === FullSyntaxTreeNodeKind.getParenthesizedExpression()) {
+            invocationExpressionTreeNode = invocationExpressionTreeNode.parentNode;
+        }
+        if (invocationExpressionTreeNode.parentNode && invocationExpressionTreeNode.parentNode.kind && invocationExpressionTreeNode.parentNode.childNodes) {
+            switch (invocationExpressionTreeNode.parentNode.kind) {
+                //TODO: Variable, Parameter, Table Field, Rec.TableField, If Statement
+                case FullSyntaxTreeNodeKind.getArgumentList():
+                    let argumentNo: number[] = ALFullSyntaxTreeNodeExt.getPathToTreeNode(invocationExpressionTreeNode.parentNode, invocationExpressionTreeNode);
+                    let signatureHelp: vscode.SignatureHelp | undefined = await vscode.commands.executeCommand('vscode.executeSignatureHelpProvider', this.document.uri, TextRangeExt.createVSCodeRange(invocationExpressionTreeNode.span).start, ',');
+                    if (signatureHelp) {
+                        let parameterName = signatureHelp.signatures[0].parameters[argumentNo[0]].label;
+                        let procedureDeclarationLine = signatureHelp.signatures[0].label;
+                        let parentInvocation: ALFullSyntaxTreeNode | undefined = invocationExpressionTreeNode.parentNode.parentNode;
+                        if (parentInvocation && parentInvocation.childNodes && parentInvocation.childNodes[0].identifier) {
+                            let declarationLineWithoutProcedureName: string = procedureDeclarationLine.substring(procedureDeclarationLine.indexOf(parentInvocation.childNodes[0].identifier) + parentInvocation.childNodes[0].identifier.length);
+                            let regExp: RegExp = new RegExp('(?:[(]|,\\s)' + parameterName + '\\s*:\\s*(?<type>[^,)]+)');
+                            let matcher: RegExpMatchArray | null = declarationLineWithoutProcedureName.match(regExp);
+                            if (matcher && matcher.groups) {
+                                return matcher.groups['type'].trim();
+                            }
+                        }
+                    }
+                    break;
+                case FullSyntaxTreeNodeKind.getUnaryMinusExpression():
+                case FullSyntaxTreeNodeKind.getUnaryPlusExpression():
+                    return 'Decimal';
+                case FullSyntaxTreeNodeKind.getIfStatement():
+                case FullSyntaxTreeNodeKind.getLogicalAndExpression():
+                case FullSyntaxTreeNodeKind.getLogicalOrExpression():
+                case FullSyntaxTreeNodeKind.getUnaryNotExpression():
+                    return 'Boolean';
+                case FullSyntaxTreeNodeKind.getArrayIndexExpression():
+                    return 'Integer';
+                case FullSyntaxTreeNodeKind.getAssignmentStatement():
+                case FullSyntaxTreeNodeKind.getCompoundAssignmentStatement():
+                case FullSyntaxTreeNodeKind.getLessThanExpression():
+                case FullSyntaxTreeNodeKind.getLessThanOrEqualExpression():
+                case FullSyntaxTreeNodeKind.getGreaterThanOrEqualExpression():
+                case FullSyntaxTreeNodeKind.getGreaterThanExpression():
+                case FullSyntaxTreeNodeKind.getEqualsExpression():
+                case FullSyntaxTreeNodeKind.getNotEqualsExpression():
+                case FullSyntaxTreeNodeKind.getAddExpression():
+                case FullSyntaxTreeNodeKind.getSubtractExpression():
+                case FullSyntaxTreeNodeKind.getMultiplyExpression():
+                case FullSyntaxTreeNodeKind.getDivideExpression():
+                    //If the parent node is one of these kinds, then it always has to be found the kind of the counterpart
+                    let indexOfInvocationTreeNode: number[] = ALFullSyntaxTreeNodeExt.getPathToTreeNode(invocationExpressionTreeNode.parentNode, invocationExpressionTreeNode);
+                    let indexOfOtherTreeNode: number = indexOfInvocationTreeNode[0] === 0 ? 1 : 0;
+                    let otherTreeNode: ALFullSyntaxTreeNode = invocationExpressionTreeNode.parentNode.childNodes[indexOfOtherTreeNode];
+
+                    let typeDetective2: TypeDetective = new TypeDetective(this.document, otherTreeNode);
+                    await typeDetective2.getTypeOfTreeNode();
+                    return typeDetective2.getType();
+            }
+        }
+        return undefined;
+    }
+
     private canObjectContainProcedures(alObject: ALObject) {
         switch (alObject.type.toString().toLowerCase()) {
             case "enum":
@@ -124,8 +126,8 @@ export class ALProcedureCallParser {
                 return true;
         }
     }
-    private async createParametersOutOfArgumentListRange(rangeOfArgumentList: vscode.Range, procedureNameToCreate: string): Promise<ALVariable[]> {
-        let parameters = await ALParameterParser.createALVariableArrayOutOfArgumentListRange(rangeOfArgumentList, this.document);
+    private async createParametersOutOfArgumentListTreeNode(argumentListTreeNode: ALFullSyntaxTreeNode, procedureNameToCreate: string): Promise<ALVariable[]> {
+        let parameters = await ALParameterParser.createALVariableArrayOutOfArgumentListTreeNode(argumentListTreeNode, this.document);
         parameters.forEach(parameter => {
             parameter.isLocal = true;
             parameter.procedure = procedureNameToCreate;

--- a/src/extension/alVariableParser.ts
+++ b/src/extension/alVariableParser.ts
@@ -1,19 +1,15 @@
 import * as vscode from 'vscode';
-import { isUndefined } from "util";
 import { ALVariable } from "./alVariable";
-import { ALSymbolHandler } from './alSymbolHandler';
 import { ALCodeOutlineExtension } from './devToolsExtensionContext';
 import { DocumentUtils } from './documentUtils';
-import { ALParameterParser } from './alParameterParser';
 import { ALFullSyntaxTreeNode } from './AL Code Outline/alFullSyntaxTreeNode';
 import { SyntaxTree } from './AL Code Outline/syntaxTree';
-import { ALFullSyntaxTreeNodeExt } from './AL Code Outline Ext/alFullSyntaxTreeNodeExt';
 import { TextRangeExt } from './AL Code Outline Ext/textRangeExt';
 import { FullSyntaxTreeNodeKind } from './AL Code Outline Ext/fullSyntaxTreeNodeKind';
 import { SyntaxTreeExt } from './AL Code Outline Ext/syntaxTreeExt';
 
 export class ALVariableParser {
-
+    
     public static async findAllVariablesInDocument(document: vscode.TextDocument): Promise<ALVariable[]> {
         let alCodeOutlineExtension = await ALCodeOutlineExtension.getInstance();
         let api = alCodeOutlineExtension.getAPI();
@@ -43,6 +39,75 @@ export class ALVariableParser {
             procedureOrTriggerName = variableSymbol.parent.parent.name;
         }
         return new ALVariable(variableSymbol.name, procedureOrTriggerName, false, variableSymbol.subtype);
+    }
+    static async parseVariableTreeNodeArrayToALVariableArray(document: vscode.TextDocument, variableTreeNodes: ALFullSyntaxTreeNode[]): Promise<ALVariable[]> {
+        let alVariables: ALVariable[] = [];
+        for(let i= 0; i < variableTreeNodes.length;i++){
+            switch (variableTreeNodes[i].kind) {
+                case FullSyntaxTreeNodeKind.getVariableDeclaration():
+                    alVariables.push(await this.parseVariableDeclarationTreeNodeToALVariable(document, variableTreeNodes[i]));
+                    break;
+                case FullSyntaxTreeNodeKind.getVariableDeclarationName():
+                    alVariables.push(await this.parseVariableDeclarationNameTreeNodeToALVariable(document, variableTreeNodes[i]));
+                    break;
+                default:
+                    throw new Error('Variable should be one of the above kinds.');
+            }
+        }
+        return alVariables;
+    }
+    static async parseVariableDeclarationTreeNodeToALVariable(document: vscode.TextDocument, variableDeclarationTreeNode: ALFullSyntaxTreeNode): Promise<ALVariable> {
+        if (!variableDeclarationTreeNode.kind || variableDeclarationTreeNode.kind !== FullSyntaxTreeNodeKind.getVariableDeclaration()) {
+            throw new Error('That\'s not a variable declaration tree node.');
+        }
+        if (variableDeclarationTreeNode.childNodes) {
+            let identifierTreeNode: ALFullSyntaxTreeNode = variableDeclarationTreeNode.childNodes[0];
+            let rangeOfName: vscode.Range = DocumentUtils.trimRange(document, TextRangeExt.createVSCodeRange(identifierTreeNode.fullSpan));
+            let identifierName = document.getText(rangeOfName);
+            let typeTreeNode: ALFullSyntaxTreeNode = variableDeclarationTreeNode.childNodes[1];
+            let rangeOfType: vscode.Range = DocumentUtils.trimRange(document, TextRangeExt.createVSCodeRange(typeTreeNode.fullSpan));
+            let type = document.getText(rangeOfType);
+            let syntaxTree: SyntaxTree = await SyntaxTree.getInstance(document);
+            let methodOrTriggerTreeNode: ALFullSyntaxTreeNode | undefined = SyntaxTreeExt.getMethodOrTriggerTreeNodeOfCurrentPosition(syntaxTree, rangeOfType.start);
+            return new ALVariable(identifierName, methodOrTriggerTreeNode?.name, false, type);
+        } else {
+            throw new Error('Variable declaration has no child nodes.');
+        }
+    }
+    static async parseVariableDeclarationNameTreeNodeToALVariable(document: vscode.TextDocument, declarationNameTreeNode: ALFullSyntaxTreeNode): Promise<ALVariable> {
+        if (!declarationNameTreeNode.kind || declarationNameTreeNode.kind !== FullSyntaxTreeNodeKind.getVariableDeclarationName()) {
+            throw new Error('That\'s not a variable declaration name tree node.');
+        }
+        if (declarationNameTreeNode.parentNode && declarationNameTreeNode.parentNode.childNodes) {
+            let rangeOfName: vscode.Range = DocumentUtils.trimRange(document, TextRangeExt.createVSCodeRange(declarationNameTreeNode.fullSpan));
+            let identifierName = document.getText(rangeOfName);
+            let typeTreeNode: ALFullSyntaxTreeNode = declarationNameTreeNode.parentNode.childNodes[declarationNameTreeNode.parentNode.childNodes.length - 1];
+            let rangeOfType: vscode.Range = DocumentUtils.trimRange(document, TextRangeExt.createVSCodeRange(typeTreeNode.fullSpan));
+            let type = document.getText(rangeOfType);
+            let syntaxTree: SyntaxTree = await SyntaxTree.getInstance(document);
+            let methodOrTriggerTreeNode: ALFullSyntaxTreeNode | undefined = SyntaxTreeExt.getMethodOrTriggerTreeNodeOfCurrentPosition(syntaxTree, rangeOfType.start);
+            return new ALVariable(identifierName, methodOrTriggerTreeNode?.name, false, type);
+        } else {
+            throw new Error('Variable declaration has no parent node.');
+        }
+    }
+    static async parseReturnValueTreeNodeToALVariable(document: vscode.TextDocument, returnVariableTreeNode: ALFullSyntaxTreeNode): Promise<ALVariable> {
+        if (!returnVariableTreeNode.kind || returnVariableTreeNode.kind !== FullSyntaxTreeNodeKind.getReturnValue()) {
+            throw new Error('That\'s not a return value tree node.');
+        }
+        if (returnVariableTreeNode.childNodes && returnVariableTreeNode.childNodes.length === 2) {
+            let identifierTreeNode: ALFullSyntaxTreeNode = returnVariableTreeNode.childNodes[0];
+            let rangeOfName: vscode.Range = DocumentUtils.trimRange(document, TextRangeExt.createVSCodeRange(identifierTreeNode.fullSpan));
+            let identifierName = document.getText(rangeOfName);
+            let typeTreeNode: ALFullSyntaxTreeNode = returnVariableTreeNode.childNodes[1];
+            let rangeOfType: vscode.Range = DocumentUtils.trimRange(document, TextRangeExt.createVSCodeRange(typeTreeNode.fullSpan));
+            let type = document.getText(rangeOfType);
+            let syntaxTree: SyntaxTree = await SyntaxTree.getInstance(document);
+            let methodOrTriggerTreeNode: ALFullSyntaxTreeNode | undefined = SyntaxTreeExt.getMethodOrTriggerTreeNodeOfCurrentPosition(syntaxTree, rangeOfType.start);
+            return new ALVariable(identifierName, methodOrTriggerTreeNode?.name, false, type);
+        } else {
+            throw new Error('Variable declaration has no child nodes.');
+        }
     }
     static async parseVariableDeclarationToALVariable(document: vscode.TextDocument, variableDeclarationTreeNode: ALFullSyntaxTreeNode): Promise<ALVariable> {
         if (variableDeclarationTreeNode.name && variableDeclarationTreeNode.childNodes && variableDeclarationTreeNode.childNodes.length > 2) {

--- a/src/extension/documentUtils.ts
+++ b/src/extension/documentUtils.ts
@@ -183,7 +183,7 @@ export class DocumentUtils {
         let newEnd: vscode.Position = currentRange.end;
         for (let i = currentRange.start.line; i <= currentRange.end.line; i++) {
             let startPositionToSearch = i === currentRange.start.line ? currentRange.start.character : 0;
-            let textStartingAtPosition = document.lineAt(i).text.substr(startPositionToSearch);
+            let textStartingAtPosition = document.lineAt(i).text.substring(startPositionToSearch);
             if (textStartingAtPosition.trimLeft().length > 0) {
                 let amountSpaces = textStartingAtPosition.length - textStartingAtPosition.trimLeft().length;
                 newStart = new vscode.Position(i, startPositionToSearch + amountSpaces);
@@ -191,8 +191,8 @@ export class DocumentUtils {
             }
         }
         for (let i = currentRange.end.line; i >= currentRange.start.line; i--) {
-            let endPositionToSearch = i === currentRange.end.line ? currentRange.end.character : document.lineAt(i).text.length - 1;
-            let textStartingAtPosition = document.lineAt(i).text.substr(0, endPositionToSearch);
+            let endPositionToSearch = i === currentRange.end.line ? currentRange.end.character : document.lineAt(i).text.length;
+            let textStartingAtPosition = document.lineAt(i).text.substring(0, endPositionToSearch);
             if (textStartingAtPosition.trimRight().length > 0) {
                 let amountSpaces = textStartingAtPosition.length - textStartingAtPosition.trimRight().length;
                 newEnd = new vscode.Position(i, endPositionToSearch - amountSpaces);

--- a/src/extension/typeDetective.ts
+++ b/src/extension/typeDetective.ts
@@ -1,0 +1,198 @@
+import * as vscode from 'vscode';
+import { SyntaxTree } from './AL Code Outline/syntaxTree';
+import { FullSyntaxTreeNodeKind } from './AL Code Outline Ext/fullSyntaxTreeNodeKind';
+import { ALFullSyntaxTreeNode } from './AL Code Outline/alFullSyntaxTreeNode';
+import { TextRangeExt } from './AL Code Outline Ext/textRangeExt';
+import { OwnConsole } from './console';
+import { DocumentUtils } from './documentUtils';
+
+export class TypeDetective {
+    private document: vscode.TextDocument;
+    // private range: vscode.Range;
+    private treeNode: ALFullSyntaxTreeNode;
+    private type: string | undefined;
+    private name: string | undefined;
+    private isVar: boolean | undefined;
+    private isTemporary: boolean | undefined;
+    constructor(document: vscode.TextDocument, treeNode: ALFullSyntaxTreeNode) {
+        this.document = document;
+        this.treeNode = treeNode;
+    }
+    public getType(): string {
+        return this.type ? this.type : '';
+    }
+    public getName(): string {
+        return this.name ? this.name : '';
+    }
+    public getIsVar(): boolean {
+        return this.isVar ? this.isVar : false;
+    }
+    public getIsTemporary(): boolean {
+        return this.isTemporary ? this.isTemporary : false;
+    }
+
+    public async getTypeOfTreeNode() {
+        switch (this.treeNode.kind) {
+            case FullSyntaxTreeNodeKind.getIdentifierName():
+                await this.getTypeOfIdentifierTreeNode(this.treeNode, this.document);
+                break;
+            case FullSyntaxTreeNodeKind.getUnaryPlusExpression():
+            case FullSyntaxTreeNodeKind.getUnaryMinusExpression():
+            case FullSyntaxTreeNodeKind.getUnaryNotExpression():
+                if (this.treeNode.childNodes) {
+                    let typeDetective: TypeDetective = new TypeDetective(this.document, this.treeNode.childNodes[0]);
+                    await typeDetective.getTypeOfTreeNode();
+                    this.name = typeDetective.getName();
+                    this.type = typeDetective.getType();
+                }
+                break;
+            case FullSyntaxTreeNodeKind.getLiteralExpression():
+                this.getTypeOfLiteralExpressionTreeNode(this.treeNode);
+                break;
+            case FullSyntaxTreeNodeKind.getInvocationExpression():
+                if (this.treeNode.childNodes) {
+                    let childNode: ALFullSyntaxTreeNode = this.treeNode.childNodes[0];
+                    let typeDetective = new TypeDetective(this.document, childNode);
+                    await typeDetective.getTypeOfTreeNode();
+                    this.name = typeDetective.getName();
+                    this.type = typeDetective.getType();
+                }
+                break;
+            case FullSyntaxTreeNodeKind.getMemberAccessExpression():
+                if (this.treeNode.childNodes) {
+                    let identifierTreeNode: ALFullSyntaxTreeNode = this.treeNode.childNodes[1];
+                    await this.getTypeOfIdentifierTreeNode(identifierTreeNode, this.document);
+                }
+                break;
+            case FullSyntaxTreeNodeKind.getParenthesizedExpression():
+                if (this.treeNode.childNodes) {
+                    let childNode: ALFullSyntaxTreeNode = this.treeNode.childNodes[0];
+                    let typeDetective: TypeDetective = new TypeDetective(this.document, childNode);
+                    await typeDetective.getTypeOfTreeNode();
+                    this.name = typeDetective.getName();
+                    this.type = typeDetective.getType();
+                }
+                break;
+            case FullSyntaxTreeNodeKind.getAddExpression():
+            case FullSyntaxTreeNodeKind.getSubtractExpression():
+            case FullSyntaxTreeNodeKind.getMultiplyExpression():
+            case FullSyntaxTreeNodeKind.getDivideExpression():
+                this.name = 'arg';
+                this.type = 'Decimal';
+                break;
+            case FullSyntaxTreeNodeKind.getLogicalAndExpression():
+            case FullSyntaxTreeNodeKind.getLogicalOrExpression():
+            case FullSyntaxTreeNodeKind.getUnaryNotExpression():
+            case FullSyntaxTreeNodeKind.getLessThanExpression():
+            case FullSyntaxTreeNodeKind.getLessThanOrEqualExpression():
+            case FullSyntaxTreeNodeKind.getGreaterThanOrEqualExpression():
+            case FullSyntaxTreeNodeKind.getGreaterThanExpression():
+            case FullSyntaxTreeNodeKind.getEqualsExpression():
+            case FullSyntaxTreeNodeKind.getNotEqualsExpression():
+                this.name = 'arg';
+                this.type = 'Boolean';
+                break;
+        }
+        if (!this.name || !this.type) {
+            this.name = 'arg';
+            this.type = 'Variant';
+        }
+    }
+    private getTypeOfLiteralExpressionTreeNode(treeNode: ALFullSyntaxTreeNode): boolean {
+        if (treeNode && treeNode.childNodes && treeNode.childNodes[0].kind) {
+            switch (treeNode.childNodes[0].kind) {
+                case FullSyntaxTreeNodeKind.getBooleanLiteralValue():
+                    this.name = 'arg';
+                    this.type = 'Boolean';
+                    return true;
+                case FullSyntaxTreeNodeKind.getStringLiteralValue():
+                    this.name = 'arg';
+                    this.type = 'Text';
+                    return true;
+                case FullSyntaxTreeNodeKind.getInt32SignedLiteralValue():
+                    this.name = 'arg';
+                    this.type = 'Integer';
+                    return true;
+                case FullSyntaxTreeNodeKind.getDecimalSignedLiteralValue():
+                    this.name = 'arg';
+                    this.type = 'Decimal';
+                    return true;
+            }
+        }
+        return false;
+    }
+    private async getTypeOfIdentifierTreeNode(identifierTreeNode: ALFullSyntaxTreeNode, document: vscode.TextDocument): Promise<boolean> {
+        if (identifierTreeNode.kind !== FullSyntaxTreeNodeKind.getIdentifierName()) {
+            throw new Error('This is not an identifier');
+        }
+        let range: vscode.Range = DocumentUtils.trimRange(this.document, TextRangeExt.createVSCodeRange(identifierTreeNode.fullSpan));
+        let position = range.start;
+        if (identifierTreeNode && identifierTreeNode.kind && identifierTreeNode.kind === FullSyntaxTreeNodeKind.getIdentifierName()) {
+            this.name = identifierTreeNode.identifier;
+
+            let hovers: vscode.Hover[] | undefined = await vscode.commands.executeCommand('vscode.executeHoverProvider', document.uri, position);
+            if (hovers && hovers.length > 0) {
+                let hoverMessage: string = hovers[0].contents.values().next().value.value;
+                let hoverMessageLines: string[] = hoverMessage.split('\r\n');
+                let startIndex = hoverMessageLines.indexOf('```al');
+                if (startIndex >= 0) {
+                    let hoverMessageFirstLine = hoverMessageLines[startIndex + 1];
+                    if (hoverMessageFirstLine.includes(':')) {
+                        this.type = hoverMessageFirstLine.substr(hoverMessageFirstLine.lastIndexOf(':') + 1).trim();
+                        if (this.type === 'Label') {
+                            this.type = 'Text';
+                        }
+                        this.checkIsVar(hoverMessageFirstLine);
+                        await this.checkIsTemporary(hoverMessageFirstLine, document, position);
+                        if (this.isTemporary) {
+                            this.type += " temporary";
+                        }
+                        return true;
+                    }
+                }
+                OwnConsole.ownConsole.appendLine('Unable to get type of hoverMessage:\r\n' + hoverMessage);
+                return false;
+            }
+            OwnConsole.ownConsole.appendLine('Unable to get hover of text:\r\n' + document.getText(range));
+            return false;
+        } else {
+            OwnConsole.ownConsole.appendLine('Unable to get type of range:\r\n' + document.getText(range));
+            return false;
+        }
+    }
+
+    private checkIsVar(hoverMessageFirstLine: string) {
+        let indexOfIdentifier: number = hoverMessageFirstLine.indexOf(this.name as string);
+        if (indexOfIdentifier >= 0) {
+            this.isVar = hoverMessageFirstLine.substring(0, indexOfIdentifier).trimRight().endsWith(' var');
+        }
+    }
+
+    private async checkIsTemporary(hoverMessageFirstLine: string, document: vscode.TextDocument, position: vscode.Position) {
+        let isVarOrParameter: boolean = hoverMessageFirstLine.startsWith('(local)') || hoverMessageFirstLine.startsWith('(global)') || hoverMessageFirstLine.startsWith('(parameter)');
+        if (isVarOrParameter) {
+            let locations: vscode.Location[] | undefined = await vscode.commands.executeCommand('vscode.executeDefinitionProvider', document.uri, position);
+            if (locations && locations.length > 0) {
+                let positionOfVariableDeclaration: vscode.Position = locations[0].range.start;
+                let syntaxTree: SyntaxTree = await SyntaxTree.getInstance(document);
+                let declarationTreeNode: ALFullSyntaxTreeNode | undefined = syntaxTree.findTreeNode(positionOfVariableDeclaration, [FullSyntaxTreeNodeKind.getVariableDeclaration(), FullSyntaxTreeNodeKind.getVariableListDeclaration(), FullSyntaxTreeNodeKind.getParameter()]);
+                if (declarationTreeNode && declarationTreeNode.kind) {
+                    switch (declarationTreeNode.kind) {
+                        case FullSyntaxTreeNodeKind.getParameter():
+                            let rangeOfDeclaration: vscode.Range = TextRangeExt.createVSCodeRange(declarationTreeNode.fullSpan);
+                            this.isTemporary = document.getText(rangeOfDeclaration).trim().toLowerCase().endsWith('temporary');
+                            break;
+                        case FullSyntaxTreeNodeKind.getVariableDeclaration():
+                        case FullSyntaxTreeNodeKind.getVariableListDeclaration():
+                            if (declarationTreeNode.childNodes) {
+                                let rangeOfTypeDeclaration: vscode.Range = TextRangeExt.createVSCodeRange(declarationTreeNode.childNodes[declarationTreeNode.childNodes.length - 1].fullSpan);
+                                this.isTemporary = document.getText(rangeOfTypeDeclaration).trim().toLowerCase().endsWith('temporary');
+                            }
+                            break;
+                    }
+                }
+
+            }
+        }
+    }
+}

--- a/src/test/suite/ALExtractProcedureCA.test.ts
+++ b/src/test/suite/ALExtractProcedureCA.test.ts
@@ -293,6 +293,27 @@ suite('ALExtractProcedureCA Test Suite', function () {
         assert.equal(alProcedure.parameters[0].isVar, true);
         assert.equal(alProcedure.variables.length, 0);
     });
+    test('ProcedureWithUsedReturnValue', async () => {
+        let procedureName = 'testProcedureWithUsedReturnValue';
+        let textToExtractStart = 'myReturnValue := Customer."No."; //extract this line';
+        let textToExtractEnd = 'myReturnValue := Customer."No."; //extract this line';
+        let rangeToExtract: vscode.Range = getRange(codeunitToExtractDocument, procedureName, textToExtractStart, textToExtractEnd);
+        let returnTypeAnalyzer: ReturnTypeAnalzyer = new ReturnTypeAnalzyer(codeunitToExtractDocument, rangeToExtract);
+        await returnTypeAnalyzer.analyze();
+        let alProcedure: ALProcedure | undefined = await new ALExtractToProcedureCA().provideProcedureObjectForCodeAction(codeunitToExtractDocument, rangeToExtract, returnTypeAnalyzer);
+        assert.notEqual(alProcedure, undefined, 'Procedure should be extracted');
+        alProcedure = alProcedure as ALProcedure;
+        assert.equal(alProcedure.isLocal, true);
+        assert.equal(alProcedure.returnType, undefined);
+        assert.equal(alProcedure.parameters.length, 2);
+        assert.equal(alProcedure.parameters[0].type.toLowerCase(), 'record customer temporary');
+        assert.equal(alProcedure.parameters[0].name.toLowerCase(), 'customer');
+        assert.equal(alProcedure.parameters[0].isVar, true);
+        assert.equal(alProcedure.parameters[1].type.toLowerCase(), 'code[20]');
+        assert.equal(alProcedure.parameters[1].name.toLowerCase(), 'myreturnvalue');
+        assert.equal(alProcedure.parameters[1].isVar, true);
+        assert.equal(alProcedure.variables.length, 0);
+    });
 
 
     function getRange(document: vscode.TextDocument, procedureName: string, textToExtractStart: string, textToExtractEnd: string): vscode.Range {


### PR DESCRIPTION
- Create Procedure Code Action
  - supports creation of procedure in Test-Methods
  - supports various more statements where procedures could be created and the return type is identified correctly, e.g.:
    - As parameter of another procedure call: The procedure takes the type of the appropriate parameter as return value.
    - If Statement: created procedure returns boolean
    - Assignment statement: created procedure returns the type of the variable which will be assigned
    - Mathematical statements like add, subtract, multiply: created procedure returns Decimal or Integer
    - Logical Statements like "true && notexistingprocedure()" returns boolean
    - ...
  - supports creation of multiline procedures
  - temporary variables will be declared as var-Parameters
- Extract to procedure Code Action
  - Remove "Preferred Fix"-Property as it isn't working and does not make much sense.
  - hand over the return value of a procedure if it is used inside the selection
- Technical rebuild of extension