### PR TITLE
Extract single expressions

### DIFF
--- a/src/extension/AL Code Outline Ext/alFullSyntaxTreeNodeExt.ts
+++ b/src/extension/AL Code Outline Ext/alFullSyntaxTreeNodeExt.ts
@@ -47,7 +47,9 @@ export class ALFullSyntaxTreeNodeExt {
         }
     }
 
-    public static reduceLevels(document: vscode.TextDocument, node: ALFullSyntaxTreeNode, lookToLeft: boolean): ALFullSyntaxTreeNode {
+    public static reduceLevels(document: vscode.TextDocument, node: ALFullSyntaxTreeNode, lookToLeft: boolean, maxReduce?: number): ALFullSyntaxTreeNode {
+        if (maxReduce === 0)
+            return node;
         let allowedCharacters: string[] = ['', ';'];
         if (node.parentNode) {
             if (lookToLeft) {
@@ -59,7 +61,7 @@ export class ALFullSyntaxTreeNodeExt {
                         node.fullSpan.start.character);
                     let textBeforeNode = document.getText(rangeBeforeNode);
                     if (allowedCharacters.includes(textBeforeNode.trim())) {
-                        return this.reduceLevels(document, node.parentNode, lookToLeft);
+                        return this.reduceLevels(document, node.parentNode, lookToLeft, maxReduce ? --maxReduce : undefined);
                     }
                 }
             } else {
@@ -71,7 +73,7 @@ export class ALFullSyntaxTreeNodeExt {
                         node.parentNode.fullSpan.end.character);
                     let textAfterNode = document.getText(rangeAfterNode);
                     if (allowedCharacters.includes(textAfterNode.trim())) {
-                        return this.reduceLevels(document, node.parentNode, lookToLeft);
+                        return this.reduceLevels(document, node.parentNode, lookToLeft, maxReduce ? --maxReduce : undefined);
                     }
                 }
             }
@@ -93,8 +95,8 @@ export class ALFullSyntaxTreeNodeExt {
             let properties: ALFullSyntaxTreeNode[] = [];
             ALFullSyntaxTreeNodeExt.collectChildNodes(propertyList, FullSyntaxTreeNodeKind.getProperty(), false, properties);
             if (properties.length > 0) {
-                let propertiesOfSearchedProperty: ALFullSyntaxTreeNode[] = properties.filter(property => 
-                    property.fullSpan && 
+                let propertiesOfSearchedProperty: ALFullSyntaxTreeNode[] = properties.filter(property =>
+                    property.fullSpan &&
                     document.getText(DocumentUtils.trimRange(document, TextRangeExt.createVSCodeRange(property.fullSpan))).toLowerCase() === propertyName.trim().toLowerCase());
                 if (propertiesOfSearchedProperty.length > 0) {
                     let propertyOfSearchedProperty: ALFullSyntaxTreeNode = propertiesOfSearchedProperty[0];

--- a/src/extension/AL Code Outline Ext/fullSyntaxTreeNodeKind.ts
+++ b/src/extension/AL Code Outline Ext/fullSyntaxTreeNodeKind.ts
@@ -104,6 +104,12 @@ export class FullSyntaxTreeNodeKind {
     public static getMemberAccessExpression(): string {
         return 'MemberAccessExpression';
     }
+    public static getInListExpression(): string{
+        return 'InListExpression';
+    }
+    public static getBracketedArgumentList(): string{
+        return 'BracketedArgumentList';
+    }
     public static getIdentifierName(): string {
         return 'IdentifierName';
     }

--- a/src/extension/Create Procedure/Procedure Creator/CreateProcedureAL0118.ts
+++ b/src/extension/Create Procedure/Procedure Creator/CreateProcedureAL0118.ts
@@ -52,7 +52,7 @@ export class CreateProcedureAL0118 implements ICreateProcedure {
         let invocationExpressionRange: vscode.Range = TextRangeExt.createVSCodeRange(invocationExpressionTreeNode.fullSpan);
         invocationExpressionRange = DocumentUtils.trimRange(this.document, invocationExpressionRange);
 
-        let returnType: string | undefined = await TypeDetective.findReturnTypeOfPosition(this.document, invocationExpressionRange);
+        let returnType: string | undefined = await TypeDetective.findReturnTypeOfInvocationAtPosition(this.document, invocationExpressionRange.start);
         return returnType;
     }
     async getObject(): Promise<ALObject> {

--- a/src/extension/Create Procedure/Procedure Creator/CreateProcedureAL0132.ts
+++ b/src/extension/Create Procedure/Procedure Creator/CreateProcedureAL0132.ts
@@ -54,7 +54,7 @@ export class CreateProcedureAL0132 implements ICreateProcedure {
         let invocationExpressionRange: vscode.Range = TextRangeExt.createVSCodeRange(invocationExpressionTreeNode.fullSpan);
         invocationExpressionRange = DocumentUtils.trimRange(this.document, invocationExpressionRange);
 
-        let returnType: string | undefined = await TypeDetective.findReturnTypeOfPosition(this.document, invocationExpressionRange);
+        let returnType: string | undefined = await TypeDetective.findReturnTypeOfInvocationAtPosition(this.document, invocationExpressionRange.start);
         return returnType;
     }
     async getObject(): Promise<ALObject> {

--- a/src/extension/Services/alExtractToProcedureCodeAction.ts
+++ b/src/extension/Services/alExtractToProcedureCodeAction.ts
@@ -47,8 +47,14 @@ export class ALExtractToProcedureCodeAction implements vscode.CodeActionProvider
             return;
         }
         let rangeExpanded: vscode.Range = rangeAnalyzer.getExpandedRange();
-        let returnTypeAnalyzer: ReturnTypeAnalyzer = new ReturnTypeAnalyzer(document, rangeExpanded);
+        let treeNodeStart: ALFullSyntaxTreeNode = rangeAnalyzer.getTreeNodeToExtractStart();
+        let treeNodeEnd: ALFullSyntaxTreeNode = rangeAnalyzer.getTreeNodeToExtractEnd();
+
+        let returnTypeAnalyzer: ReturnTypeAnalyzer = new ReturnTypeAnalyzer(document, treeNodeStart, treeNodeEnd);
         await returnTypeAnalyzer.analyze();
+        if (rangeAnalyzer.isValidToExtractOnlyWithReturnType() && !returnTypeAnalyzer.getReturnType()) {
+            return;
+        }
         let procedureObject: ALProcedure | undefined = await this.provideProcedureObjectForCodeAction(document, rangeExpanded, returnTypeAnalyzer);
         if (!procedureObject) {
             return;

--- a/src/extension/Utils/typeDetective.ts
+++ b/src/extension/Utils/typeDetective.ts
@@ -6,6 +6,7 @@ import { TextRangeExt } from '../AL Code Outline Ext/textRangeExt';
 import { OwnConsole } from '../console';
 import { DocumentUtils } from './documentUtils';
 import { ALFullSyntaxTreeNodeExt } from '../AL Code Outline Ext/alFullSyntaxTreeNodeExt';
+import { TextEncoder } from 'util';
 
 export class TypeDetective {
     private document: vscode.TextDocument;
@@ -210,22 +211,25 @@ export class TypeDetective {
             }
         }
     }
-    public static async findReturnTypeOfPosition(document: vscode.TextDocument, range: vscode.Range): Promise<string | undefined> {
+    public static async findReturnTypeOfInvocationAtPosition(document: vscode.TextDocument, position: vscode.Position): Promise<string | undefined> {
         let syntaxTree: SyntaxTree = await SyntaxTree.getInstance(document);
-        let invocationExpressionTreeNode: ALFullSyntaxTreeNode = syntaxTree.findTreeNode(range.start, [FullSyntaxTreeNodeKind.getInvocationExpression()]) as ALFullSyntaxTreeNode;
-        while (invocationExpressionTreeNode.parentNode && invocationExpressionTreeNode.parentNode.kind === FullSyntaxTreeNodeKind.getParenthesizedExpression()) {
-            invocationExpressionTreeNode = invocationExpressionTreeNode.parentNode;
+        let invocationExpressionTreeNode: ALFullSyntaxTreeNode = syntaxTree.findTreeNode(position, [FullSyntaxTreeNodeKind.getInvocationExpression()]) as ALFullSyntaxTreeNode;
+        return await this.findReturnTypeOfTreeNode(document, invocationExpressionTreeNode);
+    }
+    public static async findReturnTypeOfTreeNode(document: vscode.TextDocument, treeNode: ALFullSyntaxTreeNode): Promise<string | undefined> {
+        while (treeNode.parentNode && treeNode.parentNode.kind === FullSyntaxTreeNodeKind.getParenthesizedExpression()) {
+            treeNode = treeNode.parentNode;
         }
-        if (invocationExpressionTreeNode.parentNode && invocationExpressionTreeNode.parentNode.kind && invocationExpressionTreeNode.parentNode.childNodes) {
-            switch (invocationExpressionTreeNode.parentNode.kind) {
+        if (treeNode.parentNode && treeNode.parentNode.kind && treeNode.parentNode.childNodes) {
+            switch (treeNode.parentNode.kind) {
                 //TODO: Variable, Parameter, Table Field, Rec.TableField, If Statement
                 case FullSyntaxTreeNodeKind.getArgumentList():
-                    let argumentNo: number[] = ALFullSyntaxTreeNodeExt.getPathToTreeNode(invocationExpressionTreeNode.parentNode, invocationExpressionTreeNode);
-                    let signatureHelp: vscode.SignatureHelp | undefined = await vscode.commands.executeCommand('vscode.executeSignatureHelpProvider', document.uri, TextRangeExt.createVSCodeRange(invocationExpressionTreeNode.span).start, ',');
+                    let argumentNo: number[] = ALFullSyntaxTreeNodeExt.getPathToTreeNode(treeNode.parentNode, treeNode);
+                    let signatureHelp: vscode.SignatureHelp | undefined = await vscode.commands.executeCommand('vscode.executeSignatureHelpProvider', document.uri, TextRangeExt.createVSCodeRange(treeNode.span).start, ',');
                     if (signatureHelp) {
                         let parameterName = signatureHelp.signatures[0].parameters[argumentNo[0]].label;
                         let procedureDeclarationLine = signatureHelp.signatures[0].label;
-                        let parentInvocation: ALFullSyntaxTreeNode | undefined = invocationExpressionTreeNode.parentNode.parentNode;
+                        let parentInvocation: ALFullSyntaxTreeNode | undefined = treeNode.parentNode.parentNode;
                         if (parentInvocation && parentInvocation.childNodes) {
                             let procedureName: string | undefined;
                             switch (parentInvocation.childNodes[0].kind) {
@@ -236,7 +240,7 @@ export class TypeDetective {
                                     procedureName = parentInvocation.childNodes[0].identifier;
                                     break;
                             }
-                            if(procedureName){
+                            if (procedureName) {
                                 let declarationLineWithoutProcedureName: string = procedureDeclarationLine.substring(procedureDeclarationLine.indexOf(procedureName) + procedureName.length);
                                 let regExp: RegExp = new RegExp('(?:[(]|,\\s)' + parameterName + '\\s*:\\s*(?<type>[^,)]+)');
                                 let matcher: RegExpMatchArray | null = declarationLineWithoutProcedureName.match(regExp);
@@ -254,6 +258,7 @@ export class TypeDetective {
                 case FullSyntaxTreeNodeKind.getLogicalAndExpression():
                 case FullSyntaxTreeNodeKind.getLogicalOrExpression():
                 case FullSyntaxTreeNodeKind.getUnaryNotExpression():
+                case FullSyntaxTreeNodeKind.getInListExpression():
                     return 'Boolean';
                 case FullSyntaxTreeNodeKind.getArrayIndexExpression():
                     return 'Integer';
@@ -270,9 +275,9 @@ export class TypeDetective {
                 case FullSyntaxTreeNodeKind.getMultiplyExpression():
                 case FullSyntaxTreeNodeKind.getDivideExpression():
                     //If the parent node is one of these kinds, then it always has to be found the kind of the counterpart
-                    let indexOfInvocationTreeNode: number[] = ALFullSyntaxTreeNodeExt.getPathToTreeNode(invocationExpressionTreeNode.parentNode, invocationExpressionTreeNode);
+                    let indexOfInvocationTreeNode: number[] = ALFullSyntaxTreeNodeExt.getPathToTreeNode(treeNode.parentNode, treeNode);
                     let indexOfOtherTreeNode: number = indexOfInvocationTreeNode[0] === 0 ? 1 : 0;
-                    let otherTreeNode: ALFullSyntaxTreeNode = invocationExpressionTreeNode.parentNode.childNodes[indexOfOtherTreeNode];
+                    let otherTreeNode: ALFullSyntaxTreeNode = treeNode.parentNode.childNodes[indexOfOtherTreeNode];
 
                     let typeDetective2: TypeDetective = new TypeDetective(document, otherTreeNode);
                     await typeDetective2.getTypeOfTreeNode();

--- a/src/test/suite/ALCreateProcedureCA.test.ts
+++ b/src/test/suite/ALCreateProcedureCA.test.ts
@@ -351,6 +351,20 @@ suite('ALCreateProcedureCA Test Suite', function () {
 		assert.equal(alProcedure.getReturnTypeAsString(), "Text");
 		assert.equal(alProcedure.parameters.length, 0);
 	});
+	test('getProcedureToCreate_ReturnValueDirectlyUsed2', async () => {
+		let procedureName = 'MissingProcedureWithDirectlyUsedReturnValue2';
+		let rangeOfProcedureName = getRangeOfProcedureName(codeunit1Document, procedureName);
+		let diagnostic = new vscode.Diagnostic(rangeOfProcedureName, '');
+		diagnostic.code = SupportedDiagnosticCodes.AL0118.toString();
+		let alProcedure = await CreateProcedure.createProcedure(new CreateProcedureAL0118(codeunit1Document,diagnostic));
+		assert.notEqual(alProcedure, undefined, 'Procedure should be created');
+		alProcedure = alProcedure as ALProcedure;
+		assert.equal(alProcedure.name, procedureName);
+		assert.equal(alProcedure.isLocal, true);
+		assert.notEqual(alProcedure.returnType, undefined);
+		assert.equal(alProcedure.getReturnTypeAsString(), "Text");
+		assert.equal(alProcedure.parameters.length, 0);
+	});
 	test('getProcedureToCreate_MultilineProcedureCall', async () => {
 		let procedureName = 'MultilineProcedureCall';
 		let rangeOfProcedureName = getRangeOfProcedureName(codeunit1Document, procedureName);

--- a/src/test/suite/ALExtractProcedureCA.test.ts
+++ b/src/test/suite/ALExtractProcedureCA.test.ts
@@ -8,10 +8,14 @@ import { ALProcedure } from '../../extension/Entities/alProcedure';
 import { ReturnTypeAnalyzer } from '../../extension/Extract Procedure/returnTypeAnalyzer';
 import { ALLanguageExtension } from '../alExtension';
 import { ALTestProject } from './ALTestProject';
+import { ALFullSyntaxTreeNode } from '../../extension/AL Code Outline/alFullSyntaxTreeNode';
+import { SyntaxTree } from '../../extension/AL Code Outline/syntaxTree';
+import { FullSyntaxTreeNodeKind } from '../../extension/AL Code Outline Ext/fullSyntaxTreeNodeKind';
 
 
 suite('ALExtractProcedureCA Test Suite', function () {
     let codeunitToExtractDocument: vscode.TextDocument;
+    let syntaxTree: SyntaxTree;
     let tableDocument: vscode.TextDocument;
     this.timeout(0);
     this.beforeAll('beforeTests', async function () {
@@ -23,6 +27,7 @@ suite('ALExtractProcedureCA Test Suite', function () {
         await vscode.workspace.openTextDocument(fileName).then(document => {
             codeunitToExtractDocument = document;
         });
+        syntaxTree = await SyntaxTree.getInstance(codeunitToExtractDocument);
 
         vscode.window.showInformationMessage('Start all tests of ALExtractProcedure.');
     });
@@ -30,9 +35,11 @@ suite('ALExtractProcedureCA Test Suite', function () {
     test('MultipleDeclarationsOfVariablesInOneLine', async () => {
         let procedureName = 'OnRun';
         let textToExtractStart = 'start := 4;';
-        let textToExtractEnd = 'result := start + addend;';
+        let textToExtractEnd = 'result := start + (addend - 1) + 1;';
         let rangeToExtract: vscode.Range = getRange(codeunitToExtractDocument, procedureName, textToExtractStart, textToExtractEnd);
-        let returnTypeAnalyzer: ReturnTypeAnalyzer = new ReturnTypeAnalyzer(codeunitToExtractDocument, rangeToExtract);
+        let startTreeNode: ALFullSyntaxTreeNode = syntaxTree.findTreeNode(rangeToExtract.start, [FullSyntaxTreeNodeKind.getAssignmentStatement()]) as ALFullSyntaxTreeNode;
+        let endTreeNode: ALFullSyntaxTreeNode = syntaxTree.findTreeNode(rangeToExtract.end, [FullSyntaxTreeNodeKind.getAssignmentStatement()]) as ALFullSyntaxTreeNode;
+        let returnTypeAnalyzer: ReturnTypeAnalyzer = new ReturnTypeAnalyzer(codeunitToExtractDocument, startTreeNode, endTreeNode);
         await returnTypeAnalyzer.analyze();
         let alProcedure: ALProcedure | undefined = await new ALExtractToProcedureCodeAction().provideProcedureObjectForCodeAction(codeunitToExtractDocument, rangeToExtract, returnTypeAnalyzer);
         assert.notEqual(alProcedure, undefined, 'Procedure should be extracted');
@@ -54,7 +61,9 @@ suite('ALExtractProcedureCA Test Suite', function () {
         let textToExtractStart = 'Customer.Name := \'Test\';';
         let textToExtractEnd = 'Customer.Insert();';
         let rangeToExtract: vscode.Range = getRange(codeunitToExtractDocument, procedureName, textToExtractStart, textToExtractEnd);
-        let returnTypeAnalyzer: ReturnTypeAnalyzer = new ReturnTypeAnalyzer(codeunitToExtractDocument, rangeToExtract);
+        let startTreeNode: ALFullSyntaxTreeNode = syntaxTree.findTreeNode(rangeToExtract.start, [FullSyntaxTreeNodeKind.getAssignmentStatement()]) as ALFullSyntaxTreeNode;
+        let endTreeNode: ALFullSyntaxTreeNode = syntaxTree.findTreeNode(rangeToExtract.end, [FullSyntaxTreeNodeKind.getExpressionStatement()]) as ALFullSyntaxTreeNode;
+        let returnTypeAnalyzer: ReturnTypeAnalyzer = new ReturnTypeAnalyzer(codeunitToExtractDocument, startTreeNode, endTreeNode);
         await returnTypeAnalyzer.analyze();
         let alProcedure: ALProcedure | undefined = await new ALExtractToProcedureCodeAction().provideProcedureObjectForCodeAction(codeunitToExtractDocument, rangeToExtract, returnTypeAnalyzer);
         assert.notEqual(alProcedure, undefined, 'Procedure should be extracted');
@@ -78,7 +87,9 @@ suite('ALExtractProcedureCA Test Suite', function () {
         let textToExtractStart = 'Customer.Name := \'Test\';';
         let textToExtractEnd = 'Customer.Insert();';
         let rangeToExtract: vscode.Range = getRange(codeunitToExtractDocument, procedureName, textToExtractStart, textToExtractEnd);
-        let returnTypeAnalyzer: ReturnTypeAnalyzer = new ReturnTypeAnalyzer(codeunitToExtractDocument, rangeToExtract);
+        let startTreeNode: ALFullSyntaxTreeNode = syntaxTree.findTreeNode(rangeToExtract.start, [FullSyntaxTreeNodeKind.getAssignmentStatement()]) as ALFullSyntaxTreeNode;
+        let endTreeNode: ALFullSyntaxTreeNode = syntaxTree.findTreeNode(rangeToExtract.end, [FullSyntaxTreeNodeKind.getExpressionStatement()]) as ALFullSyntaxTreeNode;
+        let returnTypeAnalyzer: ReturnTypeAnalyzer = new ReturnTypeAnalyzer(codeunitToExtractDocument, startTreeNode, endTreeNode);
         await returnTypeAnalyzer.analyze();
         let alProcedure: ALProcedure | undefined = await new ALExtractToProcedureCodeAction().provideProcedureObjectForCodeAction(codeunitToExtractDocument, rangeToExtract, returnTypeAnalyzer);
         assert.notEqual(alProcedure, undefined, 'Procedure should be extracted');
@@ -102,7 +113,9 @@ suite('ALExtractProcedureCA Test Suite', function () {
         let textToExtractStart = 'Customer.Name := \'Test\';';
         let textToExtractEnd = 'Customer.Insert();';
         let rangeToExtract: vscode.Range = getRange(codeunitToExtractDocument, procedureName, textToExtractStart, textToExtractEnd);
-        let returnTypeAnalyzer: ReturnTypeAnalyzer = new ReturnTypeAnalyzer(codeunitToExtractDocument, rangeToExtract);
+        let startTreeNode: ALFullSyntaxTreeNode = syntaxTree.findTreeNode(rangeToExtract.start, [FullSyntaxTreeNodeKind.getAssignmentStatement()]) as ALFullSyntaxTreeNode;
+        let endTreeNode: ALFullSyntaxTreeNode = syntaxTree.findTreeNode(rangeToExtract.end, [FullSyntaxTreeNodeKind.getExpressionStatement()]) as ALFullSyntaxTreeNode;
+        let returnTypeAnalyzer: ReturnTypeAnalyzer = new ReturnTypeAnalyzer(codeunitToExtractDocument, startTreeNode, endTreeNode);
         await returnTypeAnalyzer.analyze();
         let alProcedure: ALProcedure | undefined = await new ALExtractToProcedureCodeAction().provideProcedureObjectForCodeAction(codeunitToExtractDocument, rangeToExtract, returnTypeAnalyzer);
         assert.notEqual(alProcedure, undefined, 'Procedure should be extracted');
@@ -126,7 +139,9 @@ suite('ALExtractProcedureCA Test Suite', function () {
         let textToExtractStart = 'Customer.Name := \'Test\';';
         let textToExtractEnd = 'Customer.Insert();';
         let rangeToExtract: vscode.Range = getRange(codeunitToExtractDocument, procedureName, textToExtractStart, textToExtractEnd);
-        let returnTypeAnalyzer: ReturnTypeAnalyzer = new ReturnTypeAnalyzer(codeunitToExtractDocument, rangeToExtract);
+        let startTreeNode: ALFullSyntaxTreeNode = syntaxTree.findTreeNode(rangeToExtract.start, [FullSyntaxTreeNodeKind.getAssignmentStatement()]) as ALFullSyntaxTreeNode;
+        let endTreeNode: ALFullSyntaxTreeNode = syntaxTree.findTreeNode(rangeToExtract.end, [FullSyntaxTreeNodeKind.getExpressionStatement()]) as ALFullSyntaxTreeNode;
+        let returnTypeAnalyzer: ReturnTypeAnalyzer = new ReturnTypeAnalyzer(codeunitToExtractDocument, startTreeNode, endTreeNode);
         await returnTypeAnalyzer.analyze();
         let alProcedure: ALProcedure | undefined = await new ALExtractToProcedureCodeAction().provideProcedureObjectForCodeAction(codeunitToExtractDocument, rangeToExtract, returnTypeAnalyzer);
         assert.notEqual(alProcedure, undefined, 'Procedure should be extracted');
@@ -144,7 +159,9 @@ suite('ALExtractProcedureCA Test Suite', function () {
         let textToExtractStart = 'Customer.Name := \'Test\';';
         let textToExtractEnd = 'Customer.Insert();';
         let rangeToExtract: vscode.Range = getRange(codeunitToExtractDocument, procedureName, textToExtractStart, textToExtractEnd);
-        let returnTypeAnalyzer: ReturnTypeAnalyzer = new ReturnTypeAnalyzer(codeunitToExtractDocument, rangeToExtract);
+        let startTreeNode: ALFullSyntaxTreeNode = syntaxTree.findTreeNode(rangeToExtract.start, [FullSyntaxTreeNodeKind.getAssignmentStatement()]) as ALFullSyntaxTreeNode;
+        let endTreeNode: ALFullSyntaxTreeNode = syntaxTree.findTreeNode(rangeToExtract.end, [FullSyntaxTreeNodeKind.getExpressionStatement()]) as ALFullSyntaxTreeNode;
+        let returnTypeAnalyzer: ReturnTypeAnalyzer = new ReturnTypeAnalyzer(codeunitToExtractDocument, startTreeNode, endTreeNode);
         await returnTypeAnalyzer.analyze();
         let alProcedure: ALProcedure | undefined = await new ALExtractToProcedureCodeAction().provideProcedureObjectForCodeAction(codeunitToExtractDocument, rangeToExtract, returnTypeAnalyzer);
         assert.notEqual(alProcedure, undefined, 'Procedure should be extracted');
@@ -162,7 +179,9 @@ suite('ALExtractProcedureCA Test Suite', function () {
         let textToExtractStart = 'Customer.Name := \'Test\';';
         let textToExtractEnd = 'Customer.Insert();';
         let rangeToExtract: vscode.Range = getRange(codeunitToExtractDocument, procedureName, textToExtractStart, textToExtractEnd);
-        let returnTypeAnalyzer: ReturnTypeAnalyzer = new ReturnTypeAnalyzer(codeunitToExtractDocument, rangeToExtract);
+        let startTreeNode: ALFullSyntaxTreeNode = syntaxTree.findTreeNode(rangeToExtract.start, [FullSyntaxTreeNodeKind.getAssignmentStatement()]) as ALFullSyntaxTreeNode;
+        let endTreeNode: ALFullSyntaxTreeNode = syntaxTree.findTreeNode(rangeToExtract.end, [FullSyntaxTreeNodeKind.getExpressionStatement()]) as ALFullSyntaxTreeNode;
+        let returnTypeAnalyzer: ReturnTypeAnalyzer = new ReturnTypeAnalyzer(codeunitToExtractDocument, startTreeNode, endTreeNode);
         await returnTypeAnalyzer.analyze();
         let alProcedure: ALProcedure | undefined = await new ALExtractToProcedureCodeAction().provideProcedureObjectForCodeAction(codeunitToExtractDocument, rangeToExtract, returnTypeAnalyzer);
         assert.notEqual(alProcedure, undefined, 'Procedure should be extracted');
@@ -181,7 +200,9 @@ suite('ALExtractProcedureCA Test Suite', function () {
         let textToExtractStart = 'CodeunitToExtract.procedureWithCodeunitAsParameter(CodeunitToExtract);  //extract this line';
         let textToExtractEnd = 'CodeunitToExtract.procedureWithCodeunitAsParameter(CodeunitToExtract);  //extract this line';
         let rangeToExtract: vscode.Range = getRange(codeunitToExtractDocument, procedureName, textToExtractStart, textToExtractEnd);
-        let returnTypeAnalyzer: ReturnTypeAnalyzer = new ReturnTypeAnalyzer(codeunitToExtractDocument, rangeToExtract);
+        let startTreeNode: ALFullSyntaxTreeNode = syntaxTree.findTreeNode(rangeToExtract.start, [FullSyntaxTreeNodeKind.getExpressionStatement()]) as ALFullSyntaxTreeNode;
+        let endTreeNode: ALFullSyntaxTreeNode = syntaxTree.findTreeNode(rangeToExtract.end, [FullSyntaxTreeNodeKind.getExpressionStatement()]) as ALFullSyntaxTreeNode;
+        let returnTypeAnalyzer: ReturnTypeAnalyzer = new ReturnTypeAnalyzer(codeunitToExtractDocument, startTreeNode, endTreeNode);
         await returnTypeAnalyzer.analyze();
         let alProcedure: ALProcedure | undefined = await new ALExtractToProcedureCodeAction().provideProcedureObjectForCodeAction(codeunitToExtractDocument, rangeToExtract, returnTypeAnalyzer);
         assert.notEqual(alProcedure, undefined, 'Procedure should be extracted');
@@ -200,7 +221,9 @@ suite('ALExtractProcedureCA Test Suite', function () {
         let textToExtractStart = 'MyPage.Run();  //extract this line';
         let textToExtractEnd = 'MyPage.Run();  //extract this line';
         let rangeToExtract: vscode.Range = getRange(codeunitToExtractDocument, procedureName, textToExtractStart, textToExtractEnd);
-        let returnTypeAnalyzer: ReturnTypeAnalyzer = new ReturnTypeAnalyzer(codeunitToExtractDocument, rangeToExtract);
+        let startTreeNode: ALFullSyntaxTreeNode = syntaxTree.findTreeNode(rangeToExtract.start, [FullSyntaxTreeNodeKind.getExpressionStatement()]) as ALFullSyntaxTreeNode;
+        let endTreeNode: ALFullSyntaxTreeNode = syntaxTree.findTreeNode(rangeToExtract.end, [FullSyntaxTreeNodeKind.getExpressionStatement()]) as ALFullSyntaxTreeNode;
+        let returnTypeAnalyzer: ReturnTypeAnalyzer = new ReturnTypeAnalyzer(codeunitToExtractDocument, startTreeNode, endTreeNode);
         await returnTypeAnalyzer.analyze();
         let alProcedure: ALProcedure | undefined = await new ALExtractToProcedureCodeAction().provideProcedureObjectForCodeAction(codeunitToExtractDocument, rangeToExtract, returnTypeAnalyzer);
         assert.notEqual(alProcedure, undefined, 'Procedure should be extracted');
@@ -219,7 +242,9 @@ suite('ALExtractProcedureCA Test Suite', function () {
         let textToExtractStart = 'Customer.Insert();  //extract this line';
         let textToExtractEnd = 'Customer.Insert();  //extract this line';
         let rangeToExtract: vscode.Range = getRange(codeunitToExtractDocument, procedureName, textToExtractStart, textToExtractEnd);
-        let returnTypeAnalyzer: ReturnTypeAnalyzer = new ReturnTypeAnalyzer(codeunitToExtractDocument, rangeToExtract);
+        let startTreeNode: ALFullSyntaxTreeNode = syntaxTree.findTreeNode(rangeToExtract.start, [FullSyntaxTreeNodeKind.getExpressionStatement()]) as ALFullSyntaxTreeNode;
+        let endTreeNode: ALFullSyntaxTreeNode = syntaxTree.findTreeNode(rangeToExtract.end, [FullSyntaxTreeNodeKind.getExpressionStatement()]) as ALFullSyntaxTreeNode;
+        let returnTypeAnalyzer: ReturnTypeAnalyzer = new ReturnTypeAnalyzer(codeunitToExtractDocument, startTreeNode, endTreeNode);
         await returnTypeAnalyzer.analyze();
         let alProcedure: ALProcedure | undefined = await new ALExtractToProcedureCodeAction().provideProcedureObjectForCodeAction(codeunitToExtractDocument, rangeToExtract, returnTypeAnalyzer);
         assert.notEqual(alProcedure, undefined, 'Procedure should be extracted');
@@ -240,7 +265,9 @@ suite('ALExtractProcedureCA Test Suite', function () {
         let textToExtractStart = 'Customer.Name := \'Test\'; //extract from this line';
         let textToExtractEnd = 'Customer.Insert();  //to this line';
         let rangeToExtract: vscode.Range = getRange(codeunitToExtractDocument, procedureName, textToExtractStart, textToExtractEnd);
-        let returnTypeAnalyzer: ReturnTypeAnalyzer = new ReturnTypeAnalyzer(codeunitToExtractDocument, rangeToExtract);
+        let startTreeNode: ALFullSyntaxTreeNode = syntaxTree.findTreeNode(rangeToExtract.start, [FullSyntaxTreeNodeKind.getAssignmentStatement()]) as ALFullSyntaxTreeNode;
+        let endTreeNode: ALFullSyntaxTreeNode = syntaxTree.findTreeNode(rangeToExtract.end, [FullSyntaxTreeNodeKind.getExpressionStatement()]) as ALFullSyntaxTreeNode;
+        let returnTypeAnalyzer: ReturnTypeAnalyzer = new ReturnTypeAnalyzer(codeunitToExtractDocument, startTreeNode, endTreeNode);
         await returnTypeAnalyzer.analyze();
         let alProcedure: ALProcedure | undefined = await new ALExtractToProcedureCodeAction().provideProcedureObjectForCodeAction(codeunitToExtractDocument, rangeToExtract, returnTypeAnalyzer);
         assert.notEqual(alProcedure, undefined, 'Procedure should be extracted');
@@ -258,7 +285,9 @@ suite('ALExtractProcedureCA Test Suite', function () {
         let textToExtractStart = 'Customer.Name := \'Test\'; //extract from this line';
         let textToExtractEnd = 'Customer.Insert();  //to this line';
         let rangeToExtract: vscode.Range = getRange(codeunitToExtractDocument, procedureName, textToExtractStart, textToExtractEnd);
-        let returnTypeAnalyzer: ReturnTypeAnalyzer = new ReturnTypeAnalyzer(codeunitToExtractDocument, rangeToExtract);
+        let startTreeNode: ALFullSyntaxTreeNode = syntaxTree.findTreeNode(rangeToExtract.start, [FullSyntaxTreeNodeKind.getAssignmentStatement()]) as ALFullSyntaxTreeNode;
+        let endTreeNode: ALFullSyntaxTreeNode = syntaxTree.findTreeNode(rangeToExtract.end, [FullSyntaxTreeNodeKind.getExpressionStatement()]) as ALFullSyntaxTreeNode;
+        let returnTypeAnalyzer: ReturnTypeAnalyzer = new ReturnTypeAnalyzer(codeunitToExtractDocument, startTreeNode, endTreeNode);
         await returnTypeAnalyzer.analyze();
         let alProcedure: ALProcedure | undefined = await new ALExtractToProcedureCodeAction().provideProcedureObjectForCodeAction(codeunitToExtractDocument, rangeToExtract, returnTypeAnalyzer);
         assert.notEqual(alProcedure, undefined, 'Procedure should be extracted');
@@ -282,7 +311,9 @@ suite('ALExtractProcedureCA Test Suite', function () {
         let textToExtractStart = '"Customer with Quotes".Name := \'Test\'; //extract from this line';
         let textToExtractEnd = 'isCustomerEmpty := "Customer with Quotes".IsEmpty();  //to this line';
         let rangeToExtract: vscode.Range = getRange(codeunitToExtractDocument, procedureName, textToExtractStart, textToExtractEnd);
-        let returnTypeAnalyzer: ReturnTypeAnalyzer = new ReturnTypeAnalyzer(codeunitToExtractDocument, rangeToExtract);
+        let startTreeNode: ALFullSyntaxTreeNode = syntaxTree.findTreeNode(rangeToExtract.start, [FullSyntaxTreeNodeKind.getAssignmentStatement()]) as ALFullSyntaxTreeNode;
+        let endTreeNode: ALFullSyntaxTreeNode = syntaxTree.findTreeNode(rangeToExtract.end, [FullSyntaxTreeNodeKind.getExpressionStatement()]) as ALFullSyntaxTreeNode;
+        let returnTypeAnalyzer: ReturnTypeAnalyzer = new ReturnTypeAnalyzer(codeunitToExtractDocument, startTreeNode, endTreeNode);
         await returnTypeAnalyzer.analyze();
         let alProcedure: ALProcedure | undefined = await new ALExtractToProcedureCodeAction().provideProcedureObjectForCodeAction(codeunitToExtractDocument, rangeToExtract, returnTypeAnalyzer);
         assert.notEqual(alProcedure, undefined, 'Procedure should be extracted');
@@ -302,7 +333,9 @@ suite('ALExtractProcedureCA Test Suite', function () {
         let textToExtractStart = 'Customer.Name := \'Test\'; //extract this line';
         let textToExtractEnd = 'Customer.Name := \'Test\'; //extract this line';
         let rangeToExtract: vscode.Range = getRange(codeunitToExtractDocument, procedureName, textToExtractStart, textToExtractEnd);
-        let returnTypeAnalyzer: ReturnTypeAnalyzer = new ReturnTypeAnalyzer(codeunitToExtractDocument, rangeToExtract);
+        let startTreeNode: ALFullSyntaxTreeNode = syntaxTree.findTreeNode(rangeToExtract.start, [FullSyntaxTreeNodeKind.getAssignmentStatement()]) as ALFullSyntaxTreeNode;
+        let endTreeNode: ALFullSyntaxTreeNode = syntaxTree.findTreeNode(rangeToExtract.end, [FullSyntaxTreeNodeKind.getAssignmentStatement()]) as ALFullSyntaxTreeNode;
+        let returnTypeAnalyzer: ReturnTypeAnalyzer = new ReturnTypeAnalyzer(codeunitToExtractDocument, startTreeNode, endTreeNode);
         await returnTypeAnalyzer.analyze();
         let alProcedure: ALProcedure | undefined = await new ALExtractToProcedureCodeAction().provideProcedureObjectForCodeAction(codeunitToExtractDocument, rangeToExtract, returnTypeAnalyzer);
         assert.notEqual(alProcedure, undefined, 'Procedure should be extracted');
@@ -320,7 +353,9 @@ suite('ALExtractProcedureCA Test Suite', function () {
         let textToExtractStart = 'myReturnValue := Customer."No."; //extract this line';
         let textToExtractEnd = 'myReturnValue := Customer."No."; //extract this line';
         let rangeToExtract: vscode.Range = getRange(codeunitToExtractDocument, procedureName, textToExtractStart, textToExtractEnd);
-        let returnTypeAnalyzer: ReturnTypeAnalyzer = new ReturnTypeAnalyzer(codeunitToExtractDocument, rangeToExtract);
+        let startTreeNode: ALFullSyntaxTreeNode = syntaxTree.findTreeNode(rangeToExtract.start, [FullSyntaxTreeNodeKind.getAssignmentStatement()]) as ALFullSyntaxTreeNode;
+        let endTreeNode: ALFullSyntaxTreeNode = syntaxTree.findTreeNode(rangeToExtract.end, [FullSyntaxTreeNodeKind.getAssignmentStatement()]) as ALFullSyntaxTreeNode;
+        let returnTypeAnalyzer: ReturnTypeAnalyzer = new ReturnTypeAnalyzer(codeunitToExtractDocument, startTreeNode, endTreeNode);
         await returnTypeAnalyzer.analyze();
         let alProcedure: ALProcedure | undefined = await new ALExtractToProcedureCodeAction().provideProcedureObjectForCodeAction(codeunitToExtractDocument, rangeToExtract, returnTypeAnalyzer);
         assert.notEqual(alProcedure, undefined, 'Procedure should be extracted');
@@ -336,6 +371,47 @@ suite('ALExtractProcedureCA Test Suite', function () {
         assert.equal(alProcedure.parameters[1].isVar, true);
         assert.equal(alProcedure.variables.length, 0);
     });
+    test('PartiallyExtractInListExpression', async () => {
+        let procedureName = 'OnRun';
+        let textToExtractStart = '1 in [2, 3]';
+        let textToExtractEnd = '1 in [2, 3]';
+        let rangeToExtract: vscode.Range = getRange(codeunitToExtractDocument, procedureName, textToExtractStart, textToExtractEnd);
+        let startTreeNode: ALFullSyntaxTreeNode = syntaxTree.findTreeNode(rangeToExtract.start, [FullSyntaxTreeNodeKind.getInListExpression()]) as ALFullSyntaxTreeNode;
+        let endTreeNode: ALFullSyntaxTreeNode = syntaxTree.findTreeNode(rangeToExtract.end, [FullSyntaxTreeNodeKind.getInListExpression()]) as ALFullSyntaxTreeNode;
+        let returnTypeAnalyzer: ReturnTypeAnalyzer = new ReturnTypeAnalyzer(codeunitToExtractDocument, startTreeNode, endTreeNode);
+        await returnTypeAnalyzer.analyze();
+        let alProcedure: ALProcedure | undefined = await new ALExtractToProcedureCodeAction().provideProcedureObjectForCodeAction(codeunitToExtractDocument, rangeToExtract, returnTypeAnalyzer);
+        assert.notEqual(alProcedure, undefined, 'Procedure should be extracted');
+        alProcedure = alProcedure as ALProcedure;
+        assert.equal(alProcedure.isLocal, true);
+        assert.equal(alProcedure.returnType, 'Boolean');
+        assert.equal(alProcedure.returnVariableName,'returnValue');
+        assert.equal(alProcedure.getBody(),'returnValue := 1 in [2, 3];')
+        assert.equal(alProcedure.parameters.length, 0);
+        assert.equal(alProcedure.variables.length, 0);
+    });
+    test('PartiallyExtractAssignmentStatement', async () => {
+        let procedureName = 'OnRun';
+        let textToExtractStart = '(addend - 1)';
+        let textToExtractEnd = '(addend - 1)';
+        let rangeToExtract: vscode.Range = getRange(codeunitToExtractDocument, procedureName, textToExtractStart, textToExtractEnd);
+        let startTreeNode: ALFullSyntaxTreeNode = syntaxTree.findTreeNode(rangeToExtract.start, [FullSyntaxTreeNodeKind.getParenthesizedExpression()]) as ALFullSyntaxTreeNode;
+        let endTreeNode: ALFullSyntaxTreeNode = syntaxTree.findTreeNode(rangeToExtract.end, [FullSyntaxTreeNodeKind.getParenthesizedExpression()]) as ALFullSyntaxTreeNode;
+        let returnTypeAnalyzer: ReturnTypeAnalyzer = new ReturnTypeAnalyzer(codeunitToExtractDocument, startTreeNode, endTreeNode);
+        await returnTypeAnalyzer.analyze();
+        let alProcedure: ALProcedure | undefined = await new ALExtractToProcedureCodeAction().provideProcedureObjectForCodeAction(codeunitToExtractDocument, rangeToExtract, returnTypeAnalyzer);
+        assert.notEqual(alProcedure, undefined, 'Procedure should be extracted');
+        alProcedure = alProcedure as ALProcedure;
+        assert.equal(alProcedure.isLocal, true);
+        assert.equal(alProcedure.returnType, 'Integer');
+        assert.equal(alProcedure.returnVariableName,'returnValue');
+        assert.equal(alProcedure.getBody(),'returnValue := (addend - 1);')
+        assert.equal(alProcedure.parameters.length, 1);
+        assert.equal(alProcedure.parameters[0].isVar,true);
+        assert.equal(alProcedure.parameters[0].name,'addend');
+        assert.equal(alProcedure.parameters[0].type,'Integer');
+        assert.equal(alProcedure.variables.length, 0);
+    });
 
 
     function getRange(document: vscode.TextDocument, procedureName: string, textToExtractStart: string, textToExtractEnd: string): vscode.Range {
@@ -348,7 +424,8 @@ suite('ALExtractProcedureCA Test Suite', function () {
                 inProcedure = true;
             }
             if (inProcedure) {
-                if (document.lineAt(i).text.includes(textToExtractStart)) {
+                let textOfLine: string = document.lineAt(i).text;
+                if (textOfLine.includes(textToExtractStart)) {
                     startPos = new vscode.Position(i, document.lineAt(i).text.indexOf(textToExtractStart));
                 }
                 if (startPos) {


### PR DESCRIPTION
#67 
With this update it's possible to not only extract whole statements. Now it's also possible to extract single expressions (= parts of a statement) as well. It will be recognized which return type the partly extracted expression has.