### PR TITLE
Fix #74, #71

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,5 +17,6 @@
     ],
     "cSpell.ignoreWords": [
         "createprocedures"
-    ]
+    ],
+    "debug.javascript.suggestPrettyPrinting": false
 }

--- a/src/extension/Entities/alVariable.ts
+++ b/src/extension/Entities/alVariable.ts
@@ -28,6 +28,8 @@ export class ALVariable {
     }
     private addBrackets(name: string): string {
         name = name.trim();
+        name = name.replace(/ä/g, 'ae').replace(/ö/g, 'oe').replace(/ü/g, 'ue').replace(/ß/g, 'ss');
+        name = name.replace(/Ä/g, 'Ae').replace(/Ö/g, 'Oe').replace(/Ü/g, 'Ue');
         name = name.replace(/[^\w]/g, '');
         return name;
     }

--- a/src/extension/Extract Procedure/returnTypeAnalyzer.ts
+++ b/src/extension/Extract Procedure/returnTypeAnalyzer.ts
@@ -45,6 +45,12 @@ export class ReturnTypeAnalyzer {
                 this.addVariableToExtractedRange = true;
                 return;
             }
+        } else if (this.treeNodeStart.parentNode && this.treeNodeStart.parentNode === this.treeNodeEnd.parentNode){
+            this.returnType = await TypeDetective.findReturnTypeOfTreeNode(this.document, this.treeNodeStart.parentNode);
+            if (this.returnType) {
+                this.addVariableToExtractedRange = true;
+                return;
+            }
         }
     }
     public getReturnType(): string | undefined {

--- a/src/extension/Utils/typeDetective.ts
+++ b/src/extension/Utils/typeDetective.ts
@@ -1,14 +1,13 @@
 import * as vscode from 'vscode';
-import { SyntaxTree } from '../AL Code Outline/syntaxTree';
+import { ALFullSyntaxTreeNodeExt } from '../AL Code Outline Ext/alFullSyntaxTreeNodeExt';
 import { FullSyntaxTreeNodeKind } from '../AL Code Outline Ext/fullSyntaxTreeNodeKind';
-import { ALFullSyntaxTreeNode } from '../AL Code Outline/alFullSyntaxTreeNode';
 import { TextRangeExt } from '../AL Code Outline Ext/textRangeExt';
+import { ALFullSyntaxTreeNode } from '../AL Code Outline/alFullSyntaxTreeNode';
+import { SyntaxTree } from '../AL Code Outline/syntaxTree';
 import { OwnConsole } from '../console';
 import { DocumentUtils } from './documentUtils';
-import { ALFullSyntaxTreeNodeExt } from '../AL Code Outline Ext/alFullSyntaxTreeNodeExt';
-import { TextEncoder } from 'util';
 
-export class TypeDetective {
+export class TypeDetective {    
     private document: vscode.TextDocument;
     // private range: vscode.Range;
     private treeNode: ALFullSyntaxTreeNode;
@@ -222,32 +221,22 @@ export class TypeDetective {
         }
         if (treeNode.parentNode && treeNode.parentNode.kind && treeNode.parentNode.childNodes) {
             switch (treeNode.parentNode.kind) {
-                //TODO: Variable, Parameter, Table Field, Rec.TableField, If Statement
                 case FullSyntaxTreeNodeKind.getArgumentList():
-                    let argumentNo: number[] = ALFullSyntaxTreeNodeExt.getPathToTreeNode(treeNode.parentNode, treeNode);
-                    let signatureHelp: vscode.SignatureHelp | undefined = await vscode.commands.executeCommand('vscode.executeSignatureHelpProvider', document.uri, TextRangeExt.createVSCodeRange(treeNode.span).start, ',');
-                    if (signatureHelp) {
-                        let parameterName = signatureHelp.signatures[0].parameters[argumentNo[0]].label;
-                        let procedureDeclarationLine = signatureHelp.signatures[0].label;
-                        let parentInvocation: ALFullSyntaxTreeNode | undefined = treeNode.parentNode.parentNode;
-                        if (parentInvocation && parentInvocation.childNodes) {
-                            let procedureName: string | undefined;
-                            switch (parentInvocation.childNodes[0].kind) {
-                                case FullSyntaxTreeNodeKind.getMemberAccessExpression():
-                                    procedureName = parentInvocation.childNodes[0].name;
-                                    break;
-                                case FullSyntaxTreeNodeKind.getIdentifierName():
-                                    procedureName = parentInvocation.childNodes[0].identifier;
-                                    break;
-                            }
-                            if (procedureName) {
-                                let declarationLineWithoutProcedureName: string = procedureDeclarationLine.substring(procedureDeclarationLine.indexOf(procedureName) + procedureName.length);
-                                let regExp: RegExp = new RegExp('(?:[(]|,\\s)' + parameterName + '\\s*:\\s*(?<type>[^,)]+)');
-                                let matcher: RegExpMatchArray | null = declarationLineWithoutProcedureName.match(regExp);
-                                if (matcher && matcher.groups) {
-                                    return matcher.groups['type'].trim();
-                                }
-                            }
+                    let returnType: string | undefined = await this.getReturnTypeIfInArgumentList(treeNode, document, treeNode.parentNode);
+                    if (returnType) {
+                        return returnType;
+                    }
+                    break;
+                case FullSyntaxTreeNodeKind.getExitStatement():
+                    let syntaxTree: SyntaxTree = await SyntaxTree.getInstance(document);
+                    let rangeOfExitStatement: vscode.Range = DocumentUtils.trimRange(document, TextRangeExt.createVSCodeRange(treeNode.parentNode.fullSpan));
+                    let methodOrTriggerNode: ALFullSyntaxTreeNode | undefined = syntaxTree.findTreeNode(rangeOfExitStatement.start, [FullSyntaxTreeNodeKind.getMethodDeclaration(), FullSyntaxTreeNodeKind.getTriggerDeclaration()]);
+                    if (methodOrTriggerNode) {
+                        let identifierNode: ALFullSyntaxTreeNode | undefined = ALFullSyntaxTreeNodeExt.getFirstChildNodeOfKind(methodOrTriggerNode, FullSyntaxTreeNodeKind.getIdentifierName(), false);
+                        if (identifierNode) {
+                            let typeDetective: TypeDetective = new TypeDetective(document, identifierNode);
+                            await typeDetective.getTypeOfTreeNode();
+                            return typeDetective.getType();
                         }
                     }
                     break;
@@ -285,5 +274,33 @@ export class TypeDetective {
             }
         }
         return undefined;
+    }
+    static async getReturnTypeIfInArgumentList(treeNode: ALFullSyntaxTreeNode, document: vscode.TextDocument, parentNode: ALFullSyntaxTreeNode): Promise<string | undefined> {
+        let argumentNo: number[] = ALFullSyntaxTreeNodeExt.getPathToTreeNode(parentNode, treeNode);
+        let signatureHelp: vscode.SignatureHelp | undefined = await vscode.commands.executeCommand('vscode.executeSignatureHelpProvider', document.uri, TextRangeExt.createVSCodeRange(treeNode.span).start, ',');
+        if (signatureHelp) {
+            let parameterName = signatureHelp.signatures[0].parameters[argumentNo[0]].label;
+            let procedureDeclarationLine = signatureHelp.signatures[0].label;
+            let parentInvocation: ALFullSyntaxTreeNode | undefined = parentNode.parentNode;
+            if (parentInvocation && parentInvocation.childNodes) {
+                let procedureName: string | undefined;
+                switch (parentInvocation.childNodes[0].kind) {
+                    case FullSyntaxTreeNodeKind.getMemberAccessExpression():
+                        procedureName = parentInvocation.childNodes[0].name;
+                        break;
+                    case FullSyntaxTreeNodeKind.getIdentifierName():
+                        procedureName = parentInvocation.childNodes[0].identifier;
+                        break;
+                }
+                if (procedureName) {
+                    let declarationLineWithoutProcedureName: string = procedureDeclarationLine.substring(procedureDeclarationLine.indexOf(procedureName) + procedureName.length);
+                    let regExp: RegExp = new RegExp('(?:[(]|,\\s)' + parameterName + '\\s*:\\s*(?<type>[^,)]+)');
+                    let matcher: RegExpMatchArray | null = declarationLineWithoutProcedureName.match(regExp);
+                    if (matcher && matcher.groups) {
+                        return matcher.groups['type'].trim();
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/test/suite/ALCreateProcedureCA.test.ts
+++ b/src/test/suite/ALCreateProcedureCA.test.ts
@@ -130,9 +130,11 @@ suite('ALCreateProcedureCA Test Suite', function () {
 		assert.equal(alProcedure.isLocal, true);
 		assert.notEqual(alProcedure.returnType, undefined);
 		assert.equal(alProcedure.getReturnTypeAsString(), 'Text[20]');
-		assert.equal(alProcedure.parameters.length, 1);
+		assert.equal(alProcedure.parameters.length, 2);
 		assert.equal(alProcedure.parameters[0].name, 'myInteger');
 		assert.equal(alProcedure.parameters[0].type, 'Integer');
+		assert.equal(alProcedure.parameters[1].name, 'Laenge');
+		assert.equal(alProcedure.parameters[1].type, 'Integer');
 	});
 	test('getProcedureToCreate_ReturnValue3', async () => {
 		let procedureName = 'MissingProcedureWithReturn3';
@@ -351,8 +353,8 @@ suite('ALCreateProcedureCA Test Suite', function () {
 		assert.equal(alProcedure.getReturnTypeAsString(), "Text");
 		assert.equal(alProcedure.parameters.length, 0);
 	});
-	test('getProcedureToCreate_ReturnValueDirectlyUsed2', async () => {
-		let procedureName = 'MissingProcedureWithDirectlyUsedReturnValue2';
+	test('getProcedureToCreate_ReturnValueDirectlyUsedInMemberExpression', async () => {
+		let procedureName = 'MissingProcedureWithDirectlyUsedReturnValueInMemberExpression';
 		let rangeOfProcedureName = getRangeOfProcedureName(codeunit1Document, procedureName);
 		let diagnostic = new vscode.Diagnostic(rangeOfProcedureName, '');
 		diagnostic.code = SupportedDiagnosticCodes.AL0118.toString();
@@ -724,6 +726,19 @@ suite('ALCreateProcedureCA Test Suite', function () {
 		assert.equal(alProcedure.name, procedureName);
 		assert.equal(alProcedure.isLocal, true);
 		assert.equal(alProcedure.returnType, 'Boolean');
+		assert.equal(alProcedure.parameters.length, 0);
+	});
+	test('getProcedureToCreate_InsideExitStatement', async function () {
+		let procedureName = 'MissingProcedureInExitStatement';
+		let rangeOfProcedureName = getRangeOfProcedureName(codeunit1Document, procedureName);
+		let diagnostic: vscode.Diagnostic = new vscode.Diagnostic(rangeOfProcedureName, '');
+		diagnostic.code = 'AL0118';
+		let alProcedure = await CreateProcedure.createProcedure(new CreateProcedureAL0118(codeunit1Document,diagnostic));
+		assert.notEqual(alProcedure, undefined, 'Procedure should be created');
+		alProcedure = alProcedure as ALProcedure;
+		assert.equal(alProcedure.name, procedureName);
+		assert.equal(alProcedure.isLocal, true);
+		assert.equal(alProcedure.returnType, 'Integer');
 		assert.equal(alProcedure.parameters.length, 0);
 	});
 

--- a/src/test/suite/ALExtractProcedureCA.test.ts
+++ b/src/test/suite/ALExtractProcedureCA.test.ts
@@ -312,7 +312,7 @@ suite('ALExtractProcedureCA Test Suite', function () {
         let textToExtractEnd = 'isCustomerEmpty := "Customer with Quotes".IsEmpty();  //to this line';
         let rangeToExtract: vscode.Range = getRange(codeunitToExtractDocument, procedureName, textToExtractStart, textToExtractEnd);
         let startTreeNode: ALFullSyntaxTreeNode = syntaxTree.findTreeNode(rangeToExtract.start, [FullSyntaxTreeNodeKind.getAssignmentStatement()]) as ALFullSyntaxTreeNode;
-        let endTreeNode: ALFullSyntaxTreeNode = syntaxTree.findTreeNode(rangeToExtract.end, [FullSyntaxTreeNodeKind.getExpressionStatement()]) as ALFullSyntaxTreeNode;
+        let endTreeNode: ALFullSyntaxTreeNode = syntaxTree.findTreeNode(rangeToExtract.end, [FullSyntaxTreeNodeKind.getAssignmentStatement()]) as ALFullSyntaxTreeNode;
         let returnTypeAnalyzer: ReturnTypeAnalyzer = new ReturnTypeAnalyzer(codeunitToExtractDocument, startTreeNode, endTreeNode);
         await returnTypeAnalyzer.analyze();
         let alProcedure: ALProcedure | undefined = await new ALExtractToProcedureCodeAction().provideProcedureObjectForCodeAction(codeunitToExtractDocument, rangeToExtract, returnTypeAnalyzer);


### PR DESCRIPTION
It's now also possible to create a procedure inside the exit statement and the return type is found correctly.

Furthermore the character äöü and ß of parameter names are changed to ae, oe, ue or ss.