### PR TITLE
Fix get record type parsing for unix

### DIFF
--- a/src/extension/Utils/typeDetective.ts
+++ b/src/extension/Utils/typeDetective.ts
@@ -169,7 +169,7 @@ export class TypeDetective {
                 for (const hover of hovers) {
                     let hoverMessage: string = hover.contents.values().next().value.value;
                     allHoverMessages.push(hoverMessage);
-                    let hoverMessageLines: string[] = hoverMessage.split('\r\n');
+                    let hoverMessageLines: string[] = hoverMessage.split(/\r?\n/);
                     let startIndex = hoverMessageLines.indexOf('```al');
                     if (startIndex >= 0) {
                         this.hoverMessageFirstLine = hoverMessageLines[startIndex + 1];


### PR DESCRIPTION
Hello,

First of all, thanks for your extension - it helps a lot.
I use your extension on Mac and faced an issue - CreateProcedure parse the "Record" type wrong:
<img width="583" alt="image" src="https://user-images.githubusercontent.com/45788765/234381665-dead5d8b-a333-476e-bb8a-f1999c51010f.png">

"DEMO field" is just a custom field added to customer  TableExtension


I have debugged your extension, and found that the problem is here:
`let hoverMessageLines: string[] = hoverMessage.split('\r\n');
`

I googled the problem, and found this solution - it fixed the problem on Mac:
![image](https://user-images.githubusercontent.com/45788765/234382697-cea8320d-b0f1-4ca8-82c5-ff550d3b78d4.png)

https://stackoverflow.com/questions/21895233/how-to-split-string-with-newline-n-in-node

Could you please check it on Windows, and add it to the master?
Thank you in advance.