### PR TITLE
Changed newLabel -> NewLabel

### DIFF
--- a/src/extension/Services/CodeActionProviderExtractLabel.ts
+++ b/src/extension/Services/CodeActionProviderExtractLabel.ts
@@ -101,7 +101,7 @@ export class CodeActionProviderExtractLabel implements ICodeActionProvider {
         let stringLiteralsToReplaceToo = result.stringLiteralsToReplaceToo
         const globalVariableRequired: boolean = stringLiteralsToReplaceToo.some(node => ALFullSyntaxTreeNodeExt.findParentNodeOfKind(node, [FullSyntaxTreeNodeKind.getMethodDeclaration(), FullSyntaxTreeNodeKind.getTriggerDeclaration()])?.fullSpan?.start?.line != methodOrTriggerTreeNode.fullSpan!.start!.line)
 
-        let cleanVariableName = 'newLabel';
+        let cleanVariableName = 'NewLabel';
         let edit: WorkspaceEdit = new WorkspaceEdit();
         edit.replace(this.document.uri, stringLiteralRange, cleanVariableName);
         stringLiteralsToReplaceToo.forEach(literalNode => edit.replace(this.document.uri, DocumentUtils.trimRange(this.document, TextRangeExt.createVSCodeRange(literalNode.fullSpan)), cleanVariableName));


### PR DESCRIPTION
When GitHub Copilot suggests names on variables and labels, it gets VERY inspired by the initial name.
If the label that we want to rename is named "newLabel", all suggestions will start with a lowercase letter. If the name is "NewLabel", it would suggest names that starts with a capital letter - which is standard in AL.

With this little change I hope that GitHub Copilot renaming suggestions is improved a little bit.